### PR TITLE
Ability to override default 'Name' tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,10 @@ resource "aws_vpn_connection" "default" {
   static_routes_only = "${var.vpn_connection_static_routes_only}"
 
   tags = "${merge(
-    var.tags,
     map(
       "Name", "VPN Connection between VPC ${var.vpc_id} and Customer Gateway ${var.customer_gateway_id}"
-    )
+    ),
+    var.tags
   )}"
 }
 


### PR DESCRIPTION
Provides the user the ability to override the default `Name` tag specified in the module.

## Description
According to the [Terraform documentation](https://www.terraform.io/docs/configuration/interpolation.html#merge-map1-map2-), a `merge` occurs in the following manner:

> merge(map1, map2, ...) - Returns the union of 2 or more maps. The maps are consumed in the order provided, and duplicate keys overwrite previous entries.

Therefore, a user using this module should be able to override the default `Name` attribute by switching the order that the module performs a merge.

## Motivation and Context
For the VPCs I manage, I would prefer not to have the default string of...

```
VPN Connection between VPC ${var.vpc_id} and Customer Gateway ${var.customer_gateway_id}
```

...override my values for the names of my VPN connections.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.