### PR TITLE
Fix vpn connection setup while tunnel cidr is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create_vpn_connection | Set to false to prevent the creation of a VPN Connection. | string | `true` | no |
-| create_vpn_gateway_attachment | Set to false to prevent attachment of the vGW to the VPC | string `false` | no |
+| create_vpn_gateway_attachment | Set to false to prevent attachment of the vGW to the VPC | string | `false` | no |
 | customer_gateway_id | The id of the Customer Gateway. | string | - | yes |
 | tags | Set of tags to be added to the VPN Connection resource (only if `create_vpn_connection = true`). | map | `<map>` | no |
 | tunnel1_inside_cidr | The CIDR block of the inside IP addresses for the first VPN tunnel. | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create_vpn_connection | Set to false to prevent the creation of a VPN Connection. | string | `true` | no |
+| create_vpn_gateway_attachment | Set to false to prevent attachment of the vGW to the VPC | string `false` | no |
 | customer_gateway_id | The id of the Customer Gateway. | string | - | yes |
 | tags | Set of tags to be added to the VPN Connection resource (only if `create_vpn_connection = true`). | map | `<map>` | no |
 | tunnel1_inside_cidr | The CIDR block of the inside IP addresses for the first VPN tunnel. | string | `` | no |

--- a/examples/complete-dual-vpn-gateway/README.md
+++ b/examples/complete-dual-vpn-gateway/README.md
@@ -1,0 +1,44 @@
+# Complete VPN Gateway Setup
+
+Configuration in this directory creates set of VPN Gateway related resources which may be sufficient for staging or production environment (look into [minimal-vpn-gateway](../minimal-vpn-gateway) for more simplified setup).
+
+This example creates VPN Connetions to two separate VPN Endpoints. This is high redundant VPN setup for production environment. 
+vGW and route propagation is configured in the terraform-aws-vpc module. In order to have this possibility additional variable needs to be set 
+
+```
+create_vpn_gateway_attachment = false 
+```
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| vpc_private_subnets |  | string | `<list>` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpn_connection_id |  |
+| vpn_connection_tunnel1_address |  |
+| vpn_connection_tunnel1_cgw_inside_address |  |
+| vpn_connection_tunnel1_vgw_inside_address |  |
+| vpn_connection_tunnel2_address |  |
+| vpn_connection_tunnel2_cgw_inside_address |  |
+| vpn_connection_tunnel2_vgw_inside_address |  |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-dual-vpn-gateway/main.tf
+++ b/examples/complete-dual-vpn-gateway/main.tf
@@ -1,0 +1,78 @@
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "vpn_gateway" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway.git"
+
+  vpn_gateway_id      = "${module.vpc.vgw_id}"
+  customer_gateway_id = "${aws_customer_gateway.main.id}"
+
+  tunnel1_inside_cidr   = "169.254.33.88/30"
+  tunnel2_inside_cidr   = "169.254.33.100/30"
+  vpc_id                       = "${module.vpc.vpc_id}"
+  create_vpn_gateway_attachment = false 
+}
+
+module "vpn_gateway2" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway.git"
+
+  vpn_gateway_id      = "${module.vpc.vgw_id}"
+  customer_gateway_id = "${aws_customer_gateway.secondary.id}"
+
+  tunnel1_inside_cidr   = "169.254.34.88/30"
+  tunnel2_inside_cidr   = "169.254.34.100/30"
+  vpc_id                       = "${module.vpc.vpc_id}"
+  create_vpn_gateway_attachment = false 
+}
+
+
+resource "aws_customer_gateway" "main" {
+  bgp_asn    = 65000
+  ip_address = "213.180.157.201"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "main-customer-gateway-complete-example"
+  }
+}
+
+resource "aws_customer_gateway" "secondary" {
+  bgp_asn    = 65000
+  ip_address = "213.180.157.202"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "main-customer-gateway-complete-example"
+  }
+}
+
+module "vpc" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
+
+  name = "complete-example"
+
+  cidr = "10.10.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
+  public_subnets  = [["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]]
+  redshift_subnets = ["10.10.21.0/24", "10.10.22.0/24", "10.10.23.0/24"]
+  intra_subnets = ["10.10.31.0/24", "10.10.32.0/24", "10.10.33.0/24"]
+  database_subnets = ["10.10.41.0/24", "10.10.42.0/24", "10.10.43.0/24"]
+
+  #create vGW and set route propagation only for private networks
+  enable_vpn_gateway = true
+  propagate_private_route_tables_vgw = false
+  propagate_public_route_tables_vgw  = true
+
+  tags = {
+    Owner       = "user"
+    Environment = "staging"
+    Name        = "complete"
+  }
+}
+
+
+

--- a/examples/complete-dual-vpn-gateway/main.tf
+++ b/examples/complete-dual-vpn-gateway/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vpn_gateway" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway.git"
+  source = "../../"
 
   vpn_gateway_id      = "${module.vpc.vgw_id}"
   customer_gateway_id = "${aws_customer_gateway.main.id}"
@@ -16,7 +16,7 @@ module "vpn_gateway" {
 }
 
 module "vpn_gateway2" {
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway.git"
+  source = "../../"
 
   vpn_gateway_id      = "${module.vpc.vgw_id}"
   customer_gateway_id = "${aws_customer_gateway.secondary.id}"

--- a/examples/complete-dual-vpn-gateway/outputs.tf
+++ b/examples/complete-dual-vpn-gateway/outputs.tf
@@ -1,0 +1,60 @@
+output "vpn_gateway.vpn_connection_id" {
+  value = "${module.vpn_gateway.vpn_connection_id}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel1_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel1_address}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel1_cgw_inside_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel1_cgw_inside_address}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel1_vgw_inside_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel1_vgw_inside_address}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel2_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel2_address}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel2_cgw_inside_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel2_cgw_inside_address}"
+}
+
+output "vpn_gateway.vpn_connection_tunnel2_vgw_inside_address" {
+  value = "${module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address}"
+}
+
+###VPN Connection Second VPN 
+
+
+output "vpn_gateway2.vpn_connection_id" {
+  value = "${module.vpn_gateway2.vpn_connection_id}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel1_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel1_address}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel1_cgw_inside_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel1_cgw_inside_address}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel1_vgw_inside_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel1_vgw_inside_address}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel2_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel2_address}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel2_cgw_inside_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel2_cgw_inside_address}"
+}
+
+output "vpn_gateway2.vpn_connection_tunnel2_vgw_inside_address" {
+  value = "${module.vpn_gateway2.vpn_connection_tunnel2_vgw_inside_address}"
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,10 @@
+
+locals {
+  tunnel_details_not_specified = "${length(var.tunnel1_inside_cidr) == 0 && length(var.tunnel2_inside_cidr) == 0 && length(var.tunnel1_preshared_key) == 0 && length(var.tunnel2_preshared_key) == 0}"
+}
+
 resource "aws_vpn_connection" "default" {
-  count = "${var.create_vpn_connection && length(var.tunnel1_inside_cidr) == 0 && length(var.tunnel2_inside_cidr) == 0 && length(var.tunnel1_preshared_key) == 0 && length(var.tunnel2_preshared_key) == 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.tunnel_details_not_specified ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_vpn_connection" "default" {
-  count = "${var.create_vpn_connection ? 1 : 0}"
+  count = "${var.create_vpn_connection && length(var.tunnel1_inside_cidr) == 0 && length(var.tunnel2_inside_cidr) == 0 && length(var.tunnel1_preshared_key) == 0 && length(var.tunnel2_preshared_key) == 0 ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -82,7 +82,7 @@ resource "aws_vpn_connection" "tunnel_preshared" {
 }
 
 resource "aws_vpn_gateway_attachment" "default" {
-  count = "${var.create_vpn_connection ? 1 : 0}"
+  count = "${var.create_vpn_connection && var.create_vpn_gateway_attachment ? 1 : 0}"
 
   vpc_id         = "${var.vpc_id}"
   vpn_gateway_id = "${var.vpn_gateway_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,9 @@ variable "tunnel2_preshared_key" {
   description = "The preshared key of the second VPN tunnel."
   default     = ""
 }
+
+#Attachment can be already managed by the terraform-aws-vpc module by using the enable_vpn_gateway variable
+variable "create_vpn_gateway_attachment" {
+  description = "Set to false to prevent attachment of the vGW to the VPC"
+  default     = true
+}


### PR DESCRIPTION
Hello,

I'd like to propose two changes
- As I tried to use tunnel CIDR in my VPN setup I had a problem with creating an "aws_vpn_resource".
  This module tries creating both resources named  "default" and "tunnel" for the same IPsec connection.
Fix makes sure that the "Default" resource is not created when any of var.tunnel* variables are set.

- The second change introduces new variable named "create_vpn_gateway_attachment". 
  Idea behind is to not create an association between vGW and VPC within this module
   The other module "terraform-aws-vpc" already has logic that is responsible for creating vGW and attaching it to a VPC. 
Also, a problem arises when we configure two VPN connections and we want later delete one of them (or we have direct connect). If we delete vgw attachment we cannot further use other connection. 
The new variable is set by default to true to provide backward compatibility. 