### PR TITLE
Fix aws_vpn_connection_route following changes introduced in #9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,10 @@ resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
 resource "aws_vpn_connection_route" "default" {
   count = "${var.create_vpn_connection ? (var.vpn_connection_static_routes_only ? length(var.vpn_connection_static_routes_destinations) : 0) : 0}"
 
-  vpn_connection_id      = "${element(split(",", (var.create_vpn_connection ? join(",", aws_vpn_connection.default.*.id) : "")), 0)}"
+  vpn_connection_id      = "${element(split(",", (var.create_vpn_connection ?
+                                                  join(",", concat(aws_vpn_connection.default.*.id,
+                                                                   aws_vpn_connection.tunnel.*.id,
+                                                                   aws_vpn_connection.preshared.*.id,
+                                                                   aws_vpn_connection.tunnel_preshared.*.id)) : "")), 0)}"
   destination_cidr_block = "${element(var.vpn_connection_static_routes_destinations, count.index)}"
 }


### PR DESCRIPTION
When either tunnel CIDRs or PSKs are specified the vpn connection routes are not created because of a missing id.

This PR fixes this by concatenating the 4 alternative definitions of `aws_vpn_connection`.
