### PR TITLE
Select appropriate VPN connection for routes resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.idea/

--- a/examples/complete-vpn-gateway-with-static-routes/main.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
 variable "vpc_private_subnets" {
   type = "list"
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
@@ -40,7 +44,7 @@ module "vpc" {
 
   cidr = "10.10.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
   public_subnets  = ["${var.vpc_private_subnets}"]
 

--- a/examples/complete-vpn-gateway-with-static-routes/main.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/main.tf
@@ -1,4 +1,5 @@
 variable "vpc_private_subnets" {
+  type = "list"
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
 }
 
@@ -18,8 +19,8 @@ module "vpn_gateway" {
   # tunnel inside cidr & preshared keys (optional)
   tunnel1_inside_cidr   = "169.254.33.88/30"
   tunnel2_inside_cidr   = "169.254.33.100/30"
-  tunnel1_preshared_key = "0DTiAd2&O[>pdC#qMr~#C-CL"
-  tunnel2_preshared_key = "#Z15YI$_TiP*+rCaF<AD*bXu"
+  tunnel1_preshared_key = "1234567890abcdefghijklmn"
+  tunnel2_preshared_key = "abcdefghijklmn1234567890"
 }
 
 resource "aws_customer_gateway" "main" {

--- a/examples/complete-vpn-gateway/main.tf
+++ b/examples/complete-vpn-gateway/main.tf
@@ -1,4 +1,9 @@
+provider "aws" {
+  region = "eu-central-1"
+}
+
 variable "vpc_private_subnets" {
+  type    = "list"
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
 }
 
@@ -30,7 +35,7 @@ module "vpc" {
 
   cidr = "10.10.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
   public_subnets  = ["${var.vpc_private_subnets}"]
 

--- a/examples/minimal-vpn-gateway/main.tf
+++ b/examples/minimal-vpn-gateway/main.tf
@@ -3,6 +3,7 @@ provider "aws" {
 }
 
 variable "vpc_private_subnets" {
+  type    = "list"
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
 }
 

--- a/examples/minimal-vpn-gateway/main.tf
+++ b/examples/minimal-vpn-gateway/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "vpc_private_subnets" {
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
 }
@@ -32,7 +36,7 @@ module "vpc" {
 
   cidr = "10.10.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
   public_subnets  = ["${var.vpc_private_subnets}"]
 

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,6 @@ resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
 resource "aws_vpn_connection_route" "default" {
   count = "${var.create_vpn_connection ? (var.vpn_connection_static_routes_only ? length(var.vpn_connection_static_routes_destinations) : 0) : 0}"
 
-  vpn_connection_id      = "${element(split(",", (local.create_tunner_with_internal_cidr_only ? join(",", aws_vpn_connection.tunnel.*.id) : (local.create_tunner_with_preshared_key_only ? join(",", aws_vpn_connection.preshared.*.id) : join(",", aws_vpn_connection.default.*.id)))), 0)}"
+  vpn_connection_id      = "${element(split(",", (local.create_tunner_with_internal_cidr_only ? join(",", aws_vpn_connection.tunnel.*.id) : (local.create_tunner_with_preshared_key_only ? join(",", aws_vpn_connection.preshared.*.id) : (local.tunnel_details_specified ? join(",", aws_vpn_connection.tunnel_preshared.*.id) : join(",", aws_vpn_connection.default.*.id))))), 0)}"
   destination_cidr_block = "${element(var.vpn_connection_static_routes_destinations, count.index)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,14 @@
 locals {
-  preshared_key_provided       = "${length(var.tunnel1_preshared_key) > 0 && length(var.tunnel2_preshared_key) > 0}"
-  preshared_key_not_provided   = "${!local.preshared_key_provided}"
-  internal_cidr_provided       = "${length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0}"
-  internal_cidr_not_provided   = "${!local.internal_cidr_provided}"
+  preshared_key_provided     = "${length(var.tunnel1_preshared_key) > 0 && length(var.tunnel2_preshared_key) > 0}"
+  preshared_key_not_provided = "${!local.preshared_key_provided}"
+  internal_cidr_provided     = "${length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0}"
+  internal_cidr_not_provided = "${!local.internal_cidr_provided}"
+
   tunnel_details_not_specified = "${local.internal_cidr_not_provided && local.preshared_key_not_provided}"
   tunnel_details_specified     = "${local.internal_cidr_provided && local.preshared_key_provided}"
+
+  create_tunner_with_internal_cidr_only = "${local.internal_cidr_provided && local.preshared_key_not_provided}"
+  create_tunner_with_preshared_key_only = "${local.internal_cidr_not_provided && local.preshared_key_provided }"
 }
 
 resource "aws_vpn_connection" "default" {
@@ -26,7 +30,7 @@ resource "aws_vpn_connection" "default" {
 
 ### Tunnel Inside CIDR only
 resource "aws_vpn_connection" "tunnel" {
-  count = "${var.create_vpn_connection && local.internal_cidr_provided && local.preshared_key_not_provided == 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.create_tunner_with_internal_cidr_only ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -47,7 +51,7 @@ resource "aws_vpn_connection" "tunnel" {
 
 ### Preshared Key only
 resource "aws_vpn_connection" "preshared" {
-  count = "${var.create_vpn_connection && local.internal_cidr_not_provided && local.preshared_key_provided ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.create_tunner_with_preshared_key_only ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -68,7 +72,7 @@ resource "aws_vpn_connection" "preshared" {
 
 ### Tunnel Inside CIDR and Preshared Key
 resource "aws_vpn_connection" "tunnel_preshared" {
-  count = "${var.create_vpn_connection && local.tunnel_details_specified > 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.tunnel_details_specified ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -107,6 +111,6 @@ resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
 resource "aws_vpn_connection_route" "default" {
   count = "${var.create_vpn_connection ? (var.vpn_connection_static_routes_only ? length(var.vpn_connection_static_routes_destinations) : 0) : 0}"
 
-  vpn_connection_id      = "${element(split(",", (var.create_vpn_connection ? join(",", aws_vpn_connection.default.*.id) : "")), 0)}"
+  vpn_connection_id      = "${element(split(",", (local.create_tunner_with_internal_cidr_only ? join(",", aws_vpn_connection.tunnel.*.id) : (local.create_tunner_with_preshared_key_only ? join(",", aws_vpn_connection.preshared.*.id) : join(",", aws_vpn_connection.default.*.id)))), 0)}"
   destination_cidr_block = "${element(var.vpn_connection_static_routes_destinations, count.index)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ locals {
   create_tunner_with_preshared_key_only = "${local.internal_cidr_not_provided && local.preshared_key_provided }"
 }
 
+### Fully AWS managed
 resource "aws_vpn_connection" "default" {
   count = "${var.create_vpn_connection && local.tunnel_details_not_specified ? 1 : 0}"
 

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
   internal_cidr_provided       = "${length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0}"
   internal_cidr_not_provided   = "${!local.internal_cidr_provided}"
   tunnel_details_not_specified = "${local.internal_cidr_not_provided && local.preshared_key_not_provided}"
+  tunnel_details_specified     = "${local.internal_cidr_provided && local.preshared_key_provided}"
 }
 
 resource "aws_vpn_connection" "default" {
@@ -25,7 +26,7 @@ resource "aws_vpn_connection" "default" {
 
 ### Tunnel Inside CIDR only
 resource "aws_vpn_connection" "tunnel" {
-  count = "${var.create_vpn_connection && length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0 && length(var.tunnel1_preshared_key) == 0 && length(var.tunnel2_preshared_key) == 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.internal_cidr_provided && local.preshared_key_not_provided == 0 ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -46,7 +47,7 @@ resource "aws_vpn_connection" "tunnel" {
 
 ### Preshared Key only
 resource "aws_vpn_connection" "preshared" {
-  count = "${var.create_vpn_connection && length(var.tunnel1_inside_cidr) == 0  && length(var.tunnel2_inside_cidr) == 0 && length(var.tunnel1_preshared_key) > 0 && length(var.tunnel2_preshared_key) > 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.internal_cidr_not_provided && local.preshared_key_provided ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"
@@ -67,7 +68,7 @@ resource "aws_vpn_connection" "preshared" {
 
 ### Tunnel Inside CIDR and Preshared Key
 resource "aws_vpn_connection" "tunnel_preshared" {
-  count = "${var.create_vpn_connection && length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0 && length(var.tunnel1_preshared_key) > 0 && length(var.tunnel2_preshared_key) > 0 ? 1 : 0}"
+  count = "${var.create_vpn_connection && local.tunnel_details_specified > 0 ? 1 : 0}"
 
   vpn_gateway_id      = "${var.vpn_gateway_id}"
   customer_gateway_id = "${var.customer_gateway_id}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
 locals {
-  tunnel_details_not_specified = "${length(var.tunnel1_inside_cidr) == 0 && length(var.tunnel2_inside_cidr) == 0 && length(var.tunnel1_preshared_key) == 0 && length(var.tunnel2_preshared_key) == 0}"
+  preshared_key_provided       = "${length(var.tunnel1_preshared_key) > 0 && length(var.tunnel2_preshared_key) > 0}"
+  preshared_key_not_provided   = "${!local.preshared_key_provided}"
+  internal_cidr_provided       = "${length(var.tunnel1_inside_cidr) > 0 && length(var.tunnel2_inside_cidr) > 0}"
+  internal_cidr_not_provided   = "${!local.internal_cidr_provided}"
+  tunnel_details_not_specified = "${local.internal_cidr_not_provided && local.preshared_key_not_provided}"
 }
 
 resource "aws_vpn_connection" "default" {


### PR DESCRIPTION
This PR refactors the logical conditions involved in selecting which VPN connection to create (default, tunnel or preshared). It then applies those logical conditions to the resource that creates vpn connection routes in order to select the right VPN connection id.

Since the 3 different logical conditions are mutually exclusive, this PR adds conditionals to determine if tunnel should be used, else if preshared should be used, or (by exclusion) default should be used.

Fixes #6 