### PR TITLE
Fix format

### DIFF
--- a/examples/complete-vpn-gateway-with-static-routes/main.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 variable "vpc_private_subnets" {
-  type = "list"
+  type    = "list"
   default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
 }
 


### PR DESCRIPTION
We run `terraform fmt`on each of our builds. So every run the module is marked for a format change. Would be nice to have this fixed, so we can enable `--check=true` on `terraform fmt`again. :)