### PR TITLE
Add support for Transit Gateway

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
+  rev: v1.22.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This module will create static routes for the VPN Connection if configured to cr
 The static routes will then be automatically propagated to the VPC subnet routing tables (provided in `private_route_table_ids`) once a VPN tunnel status is `UP`.
 When static routes are disabled, the appliance behind the Customer Gateway needs to support BGP routing protocol in order for routes to be automatically discovered, and subsequently propagated to the VPC subnet routing tables.
 This module supports optional parameters for tunnel inside cidr and preshared keys. They can be supplied individually, too.
+If you want to use the Transit Gateway support you are responsible for creating the transit gateway, the route tables and the association yourself outside of this module.
 
 ## Usage
 
@@ -120,25 +121,28 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| connect\_to\_transit\_gateway | Whether to connect to a transit gateway(true) or a VPN gateway (false) | bool | `"false"` | no |
 | create\_vpn\_connection | Set to false to prevent the creation of a VPN Connection. | bool | `"true"` | no |
 | create\_vpn\_gateway\_attachment | Set to false to prevent attachment of the vGW to the VPC | bool | `"true"` | no |
 | customer\_gateway\_id | The id of the Customer Gateway. | string | n/a | yes |
 | tags | Set of tags to be added to the VPN Connection resource (only if `create_vpn_connection = true`). | map(string) | `{}` | no |
+| transit\_gateway\_id | The transit gateway ID to link the VPN connection to | string | null | no |
 | tunnel1\_inside\_cidr | The CIDR block of the inside IP addresses for the first VPN tunnel. | string | `""` | no |
 | tunnel1\_preshared\_key | The preshared key of the first VPN tunnel. | string | `""` | no |
 | tunnel2\_inside\_cidr | The CIDR block of the inside IP addresses for the second VPN tunnel. | string | `""` | no |
 | tunnel2\_preshared\_key | The preshared key of the second VPN tunnel. | string | `""` | no |
-| vpc\_id | The id of the VPC where the VPN Gateway lives. | string | n/a | yes |
+| vpc\_id | The id of the VPC where the VPN Gateway lives. (Required if specifying a vpn_gateway_id) | string | n/a | yes |
 | vpc\_subnet\_route\_table\_count | The number of subnet route table ids being passed in via `vpc_subnet_route_table_ids`. | number | `"0"` | no |
 | vpc\_subnet\_route\_table\_ids | The ids of the VPC subnets for which routes from the VPN Gateway will be propagated. | list(string) | `[]` | no |
 | vpn\_connection\_static\_routes\_destinations | List of CIDRs to be used as destination for static routes (used with `vpn_connection_static_routes_only = true`). Routes to destinations set here will be propagated to the routing tables of the subnets defined in `vpc_subnet_route_table_ids`. | list(string) | `[]` | no |
 | vpn\_connection\_static\_routes\_only | Set to true for the created VPN connection to use static routes exclusively (only if `create_vpn_connection = true`). Static routes must be used for devices that don't support BGP. | bool | `"false"` | no |
-| vpn\_gateway\_id | The id of the VPN Gateway. | string | n/a | yes |
+| vpn\_gateway\_id | The id of the VPN Gateway. (Mutually exclusive with `transit_gateway_id`) | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| transit\_gateway\_attachment\_id | The resulting transit gateway attachment ID if `transit_gateway_id` was set as input |
 | vpn\_connection\_id | A list with the VPN Connection ID if `create_vpn_connection = true`, or empty otherwise |
 | vpn\_connection\_tunnel1\_address | A list with the the public IP address of the first VPN tunnel if `create_vpn_connection = true`, or empty otherwise |
 | vpn\_connection\_tunnel1\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "vpn_gateway" {
 
   vpc_id                  = module.vpc.vpc_id
   vpn_gateway_id          = module.vpc.vgw_id
-  customer_gateway_id     = aws_customer_gateway.main.id
+  customer_gateway_id     = module.vpc.cgw_ids[0]
 
   # precalculated length of module variable vpc_subnet_route_table_ids
   vpc_subnet_route_table_count = 3
@@ -48,21 +48,23 @@ module "vpn_gateway" {
   tunnel2_preshared_key = var.custom_tunnel2_preshared_key
 }
 
-resource "aws_customer_gateway" "main" {
-  bgp_asn    = 65000
-  ip_address = "172.83.124.10"
-  type       = "ipsec.1"
-
-  tags {
-    Name = "main-customer-gateway"
-  }
-}
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 2.0"
 
   enable_vpn_gateway = true
+  amazon_side_asn    = 64620
+  
+  customer_gateways = {
+    IP1 = {
+      bgp_asn    = 65220
+      ip_address = "172.83.124.10"
+    },
+    IP2 = {
+      bgp_asn    = 65220
+      ip_address = "172.83.124.11"
+    }
+  }
 
   # ...
 }
@@ -110,9 +112,60 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 }
 ```
 
+##### With VPC module and Transit Gateway resources
+
+```hcl
+module "vpn_gateway" {
+  source  = "terraform-aws-modules/vpn-gateway/aws"
+  version = "~> 2.0"
+
+  transit_gateway_id  = aws_ec2_transit_gateway.this.id
+  customer_gateway_id = module.vpc.cgw_ids[0]
+
+  # tunnel inside cidr & preshared keys (optional)
+  tunnel1_inside_cidr   = var.custom_tunnel1_inside_cidr
+  tunnel2_inside_cidr   = var.custom_tunnel2_inside_cidr
+  tunnel1_preshared_key = var.custom_tunnel1_preshared_key
+  tunnel2_preshared_key = var.custom_tunnel2_preshared_key
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.0"
+
+  enable_vpn_gateway = true
+  amazon_side_asn    = 64620
+  
+  customer_gateways = {
+    IP1 = {
+      bgp_asn    = 65220
+      ip_address = "172.83.124.10"
+    },
+    IP2 = {
+      bgp_asn    = 65220
+      ip_address = "172.83.124.11"
+    }
+  }
+
+  # ...
+}
+
+resource "aws_ec2_transit_gateway" "this" {
+  description = "My TGW"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  subnet_ids         = module.vpc.private_subnets
+  vpc_id             = module.vpc.vpc_id
+  transit_gateway_id = aws_ec2_transit_gateway.this.id
+}
+
+```
+
 ## Examples
 
-* [Complete example](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/tree/master/examples/complete-vpn-gateway) shows how to create all VPN Gateway resources.
+* [Complete example](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/tree/master/examples/complete-vpn-gateway) shows how to create all VPN Gateway resources and integration with VPC module.
+* [Complete example with Transit Gateway](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/tree/master/examples/complete-vpn-connection-transit-gateway) shows how to create VPN Connection between Transit Gateway and Customer Gateway.
 * [Complete example with static routes](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/tree/master/examples/complete-vpn-gateway-with-static-routes) shows how to create all VPN Gateway together with static routes.
 * [Minimal example](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/tree/master/examples/minimal-vpn-gateway) shows how to create just VPN Gateway using this module.
 
@@ -121,35 +174,35 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| connect\_to\_transit\_gateway | Whether to connect to a transit gateway(true) or a VPN gateway (false) | bool | `"false"` | no |
 | create\_vpn\_connection | Set to false to prevent the creation of a VPN Connection. | bool | `"true"` | no |
 | create\_vpn\_gateway\_attachment | Set to false to prevent attachment of the vGW to the VPC | bool | `"true"` | no |
 | customer\_gateway\_id | The id of the Customer Gateway. | string | n/a | yes |
-| tags | Set of tags to be added to the VPN Connection resource (only if `create_vpn_connection = true`). | map(string) | `{}` | no |
-| transit\_gateway\_id | The transit gateway ID to link the VPN connection to | string | null | no |
+| tags | Set of tags to be added to the VPN Connection resource \(only if `create\_vpn\_connection = true`\). | map(string) | `{}` | no |
+| transit\_gateway\_id | The ID of the Transit Gateway. | string | `"null"` | no |
 | tunnel1\_inside\_cidr | The CIDR block of the inside IP addresses for the first VPN tunnel. | string | `""` | no |
 | tunnel1\_preshared\_key | The preshared key of the first VPN tunnel. | string | `""` | no |
 | tunnel2\_inside\_cidr | The CIDR block of the inside IP addresses for the second VPN tunnel. | string | `""` | no |
 | tunnel2\_preshared\_key | The preshared key of the second VPN tunnel. | string | `""` | no |
-| vpc\_id | The id of the VPC where the VPN Gateway lives. (Required if specifying a vpn_gateway_id) | string | n/a | yes |
-| vpc\_subnet\_route\_table\_count | The number of subnet route table ids being passed in via `vpc_subnet_route_table_ids`. | number | `"0"` | no |
+| vpc\_id | The id of the VPC where the VPN Gateway lives. | string | `"null"` | no |
+| vpc\_subnet\_route\_table\_count | The number of subnet route table ids being passed in via `vpc\_subnet\_route\_table\_ids`. | number | `"0"` | no |
 | vpc\_subnet\_route\_table\_ids | The ids of the VPC subnets for which routes from the VPN Gateway will be propagated. | list(string) | `[]` | no |
-| vpn\_connection\_static\_routes\_destinations | List of CIDRs to be used as destination for static routes (used with `vpn_connection_static_routes_only = true`). Routes to destinations set here will be propagated to the routing tables of the subnets defined in `vpc_subnet_route_table_ids`. | list(string) | `[]` | no |
-| vpn\_connection\_static\_routes\_only | Set to true for the created VPN connection to use static routes exclusively (only if `create_vpn_connection = true`). Static routes must be used for devices that don't support BGP. | bool | `"false"` | no |
-| vpn\_gateway\_id | The id of the VPN Gateway. (Mutually exclusive with `transit_gateway_id`) | string | n/a | yes |
+| vpn\_connection\_static\_routes\_destinations | List of CIDRs to be used as destination for static routes \(used with `vpn\_connection\_static\_routes\_only = true`\). Routes to destinations set here will be propagated to the routing tables of the subnets defined in `vpc\_subnet\_route\_table\_ids`. | list(string) | `[]` | no |
+| vpn\_connection\_static\_routes\_only | Set to true for the created VPN connection to use static routes exclusively \(only if `create\_vpn\_connection = true`\). Static routes must be used for devices that don't support BGP. | bool | `"false"` | no |
+| vpn\_gateway\_id | The id of the VPN Gateway. | string | `"null"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| transit\_gateway\_attachment\_id | The resulting transit gateway attachment ID if `transit_gateway_id` was set as input |
-| vpn\_connection\_id | A list with the VPN Connection ID if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel1\_address | A list with the the public IP address of the first VPN tunnel if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel1\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel1\_vgw\_inside\_address | A list with the the RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel2\_address | A list with the the public IP address of the second VPN tunnel if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel2\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
-| vpn\_connection\_tunnel2\_vgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
+| vpn\_connection\_customer\_gateway\_configuration | The configuration information for the VPN connection's customer gateway \(in the native XML format\) if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_id | A list with the VPN Connection ID if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_transit\_gateway\_attachment\_id | The transit gateway attachment ID that was generated when attaching this VPN connection. |
+| vpn\_connection\_tunnel1\_address | A list with the the public IP address of the first VPN tunnel if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_tunnel1\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the first VPN tunnel \(Customer Gateway Side\) if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_tunnel1\_vgw\_inside\_address | A list with the the RFC 6890 link-local address of the first VPN tunnel \(VPN Gateway Side\) if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_tunnel2\_address | A list with the the public IP address of the second VPN tunnel if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_tunnel2\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel \(Customer Gateway Side\) if `create\_vpn\_connection = true`, or empty otherwise |
+| vpn\_connection\_tunnel2\_vgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel \(VPN Gateway Side\) if `create\_vpn\_connection = true`, or empty otherwise |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -1,8 +1,6 @@
-# Complete VPN Gateway Setup with Transit Gateway
+# Complete VPN Connection with Transit Gateway
 
-Configuration in this directory creates set of VPN Gateway related resources which may be sufficient for staging or production environment (look into [minimal-vpn-gateway](../minimal-vpn-gateway) for more simplified setup).
-
-There will be a VPN Connection created which is linked to a transit gateway. This transit gateway is linked to a sample VPC which will be created for you.
+Configuration in this directory creates two VPN Connections (one per Customer Gateway) linked to Transit Gateway which is connected to private subnets of VPC.
 
 ## Usage
 
@@ -29,11 +27,12 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Description |
 |------|-------------|
 | vpn\_connection\_id |  |
+| vpn\_connection\_transit\_gateway\_attachment\_id |  |
 | vpn\_connection\_tunnel1\_address |  |
 | vpn\_connection\_tunnel1\_cgw\_inside\_address |  |
 | vpn\_connection\_tunnel1\_vgw\_inside\_address |  |
 | vpn\_connection\_tunnel2\_address |  |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address |  |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address |  |
-| transit\_gateway\_attachment\_id | |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -1,0 +1,39 @@
+# Complete VPN Gateway Setup with Transit Gateway
+
+Configuration in this directory creates set of VPN Gateway related resources which may be sufficient for staging or production environment (look into [minimal-vpn-gateway](../minimal-vpn-gateway) for more simplified setup).
+
+There will be a VPN Connection created which is linked to a transit gateway. This transit gateway is linked to a sample VPC which will be created for you.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| vpc\_private\_subnets |  | list(string) | `[ "10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24" ]` | no |
+| vpc\_public\_subnets |  | list(string) | `[ "10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24" ]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpn\_connection\_id |  |
+| vpn\_connection\_tunnel1\_address |  |
+| vpn\_connection\_tunnel1\_cgw\_inside\_address |  |
+| vpn\_connection\_tunnel1\_vgw\_inside\_address |  |
+| vpn\_connection\_tunnel2\_address |  |
+| vpn\_connection\_tunnel2\_cgw\_inside\_address |  |
+| vpn\_connection\_tunnel2\_vgw\_inside\_address |  |
+| transit\_gateway\_attachment\_id | |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-connection-transit-gateway/main.tf
+++ b/examples/complete-vpn-connection-transit-gateway/main.tf
@@ -1,0 +1,74 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+variable "vpc_private_subnets" {
+  type    = list(string)
+  default = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
+}
+
+variable "vpc_public_subnets" {
+  type    = list(string)
+  default = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
+}
+
+module "vpn_gateway" {
+  source = "../../"
+
+  create_vpn_gateway_attachment = false
+
+  transit_gateway_id         = aws_ec2_transit_gateway.example.id
+  customer_gateway_id        = aws_customer_gateway.main.id
+  connect_to_transit_gateway = true
+
+  # tunnel inside cidr & preshared keys (optional)
+  tunnel1_inside_cidr   = "169.254.33.88/30"
+  tunnel2_inside_cidr   = "169.254.33.100/30"
+  tunnel1_preshared_key = "1234567890abcdefghijklmn"
+  tunnel2_preshared_key = "abcdefghijklmn1234567890"
+
+}
+
+resource "aws_customer_gateway" "main" {
+  bgp_asn    = 65000
+  ip_address = "172.83.124.11"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = "complete-vpn-gateway-transit-gateway"
+  }
+
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.0"
+
+  name = "complete-vpn-gateway-transit-gateway"
+
+  cidr = "10.10.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = var.vpc_private_subnets
+  public_subnets  = var.vpc_public_subnets
+
+  enable_nat_gateway = false
+
+  enable_vpn_gateway = false
+
+  tags = {
+    Owner       = "user"
+    Environment = "staging"
+    Name        = "complete"
+  }
+}
+
+resource "aws_ec2_transit_gateway" "example" {
+  description = "complete-vpn-gateway-transit-gateway"
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
+  subnet_ids         = module.vpc.private_subnets
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  vpc_id             = module.vpc.vpc_id
+}

--- a/examples/complete-vpn-connection-transit-gateway/main.tf
+++ b/examples/complete-vpn-connection-transit-gateway/main.tf
@@ -68,7 +68,6 @@ module "vpc" {
   tags = {
     Owner       = "user"
     Environment = "staging"
-    Name        = "complete"
   }
 }
 

--- a/examples/complete-vpn-connection-transit-gateway/outputs.tf
+++ b/examples/complete-vpn-connection-transit-gateway/outputs.tf
@@ -1,0 +1,31 @@
+output "vpn_connection_id" {
+  value = module.vpn_gateway.vpn_connection_id
+}
+
+output "vpn_connection_tunnel1_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel1_address
+}
+
+output "vpn_connection_tunnel1_cgw_inside_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel1_cgw_inside_address
+}
+
+output "vpn_connection_tunnel1_vgw_inside_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel1_vgw_inside_address
+}
+
+output "vpn_connection_tunnel2_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel2_address
+}
+
+output "vpn_connection_tunnel2_cgw_inside_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel2_cgw_inside_address
+}
+
+output "vpn_connection_tunnel2_vgw_inside_address" {
+  value = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
+}
+
+output "transit_gateway_attachment_id" {
+  value = module.vpn_gateway.transit_gateway_attachment_id
+}

--- a/examples/complete-vpn-connection-transit-gateway/outputs.tf
+++ b/examples/complete-vpn-connection-transit-gateway/outputs.tf
@@ -1,31 +1,31 @@
 output "vpn_connection_id" {
-  value = module.vpn_gateway.vpn_connection_id
+  value = module.vpn_gateway_1.vpn_connection_id
 }
 
 output "vpn_connection_tunnel1_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel1_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel1_address
 }
 
 output "vpn_connection_tunnel1_cgw_inside_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel1_cgw_inside_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel1_cgw_inside_address
 }
 
 output "vpn_connection_tunnel1_vgw_inside_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel1_vgw_inside_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel1_vgw_inside_address
 }
 
 output "vpn_connection_tunnel2_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel2_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel2_address
 }
 
 output "vpn_connection_tunnel2_cgw_inside_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel2_cgw_inside_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel2_cgw_inside_address
 }
 
 output "vpn_connection_tunnel2_vgw_inside_address" {
-  value = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
+  value = module.vpn_gateway_1.vpn_connection_tunnel2_vgw_inside_address
 }
 
-output "transit_gateway_attachment_id" {
-  value = module.vpn_gateway.transit_gateway_attachment_id
+output "vpn_connection_transit_gateway_attachment_id" {
+  value = module.vpn_gateway_1.vpn_connection_transit_gateway_attachment_id
 }

--- a/main.tf
+++ b/main.tf
@@ -10,18 +10,19 @@ locals {
   create_tunner_with_internal_cidr_only = local.internal_cidr_provided && local.preshared_key_not_provided
   create_tunner_with_preshared_key_only = local.internal_cidr_not_provided && local.preshared_key_provided
 
-  connection_identifier      = ! var.connect_to_transit_gateway ? "VPC ${var.vpc_id}" : "TGW ${var.transit_gateway_id}"
+  connect_to_transit_gateway = var.transit_gateway_id != ""
+  connection_identifier      = local.connect_to_transit_gateway ? "TGW ${var.transit_gateway_id}" : "VPC ${var.vpc_id}"
   name_tag                   = "VPN Connection between ${local.connection_identifier} and Customer Gateway ${var.customer_gateway_id}"
-
 }
 
 ### Fully AWS managed
 resource "aws_vpn_connection" "default" {
   count = var.create_vpn_connection && local.tunnel_details_not_specified ? 1 : 0
 
-  vpn_gateway_id      = var.vpn_gateway_id
+  vpn_gateway_id     = var.vpn_gateway_id
+  transit_gateway_id = var.transit_gateway_id
+
   customer_gateway_id = var.customer_gateway_id
-  transit_gateway_id  = var.transit_gateway_id
   type                = "ipsec.1"
 
   static_routes_only = var.vpn_connection_static_routes_only
@@ -38,9 +39,10 @@ resource "aws_vpn_connection" "default" {
 resource "aws_vpn_connection" "tunnel" {
   count = var.create_vpn_connection && local.create_tunner_with_internal_cidr_only ? 1 : 0
 
-  vpn_gateway_id      = var.vpn_gateway_id
+  vpn_gateway_id     = var.vpn_gateway_id
+  transit_gateway_id = var.transit_gateway_id
+
   customer_gateway_id = var.customer_gateway_id
-  transit_gateway_id  = var.transit_gateway_id
   type                = "ipsec.1"
 
   static_routes_only = var.vpn_connection_static_routes_only
@@ -60,9 +62,10 @@ resource "aws_vpn_connection" "tunnel" {
 resource "aws_vpn_connection" "preshared" {
   count = var.create_vpn_connection && local.create_tunner_with_preshared_key_only ? 1 : 0
 
-  vpn_gateway_id      = var.vpn_gateway_id
+  vpn_gateway_id     = var.vpn_gateway_id
+  transit_gateway_id = var.transit_gateway_id
+
   customer_gateway_id = var.customer_gateway_id
-  transit_gateway_id  = var.transit_gateway_id
   type                = "ipsec.1"
 
   static_routes_only = var.vpn_connection_static_routes_only
@@ -82,9 +85,10 @@ resource "aws_vpn_connection" "preshared" {
 resource "aws_vpn_connection" "tunnel_preshared" {
   count = var.create_vpn_connection && local.tunnel_details_specified ? 1 : 0
 
-  vpn_gateway_id      = var.vpn_gateway_id
+  vpn_gateway_id     = var.vpn_gateway_id
+  transit_gateway_id = var.transit_gateway_id
+
   customer_gateway_id = var.customer_gateway_id
-  transit_gateway_id  = var.transit_gateway_id
   type                = "ipsec.1"
 
   static_routes_only = var.vpn_connection_static_routes_only
@@ -104,21 +108,21 @@ resource "aws_vpn_connection" "tunnel_preshared" {
 }
 
 resource "aws_vpn_gateway_attachment" "default" {
-  count = var.create_vpn_connection && var.create_vpn_gateway_attachment && ! var.connect_to_transit_gateway ? 1 : 0
+  count = var.create_vpn_connection && var.create_vpn_gateway_attachment && ! local.connect_to_transit_gateway ? 1 : 0
 
   vpc_id         = var.vpc_id
   vpn_gateway_id = var.vpn_gateway_id
 }
 
 resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
-  count = var.create_vpn_connection && ! var.connect_to_transit_gateway ? var.vpc_subnet_route_table_count : 0
+  count = var.create_vpn_connection && ! local.connect_to_transit_gateway ? var.vpc_subnet_route_table_count : 0
 
   vpn_gateway_id = var.vpn_gateway_id
   route_table_id = element(var.vpc_subnet_route_table_ids, count.index)
 }
 
 resource "aws_vpn_connection_route" "default" {
-  count = var.create_vpn_connection && var.vpn_connection_static_routes_only && ! var.connect_to_transit_gateway ? length(var.vpn_connection_static_routes_destinations) : 0
+  count = var.create_vpn_connection && var.vpn_connection_static_routes_only && ! local.connect_to_transit_gateway ? length(var.vpn_connection_static_routes_destinations) : 0
 
   vpn_connection_id = local.create_tunner_with_internal_cidr_only ? aws_vpn_connection.tunnel[0].id : local.create_tunner_with_preshared_key_only ? aws_vpn_connection.preshared[0].id : local.tunnel_details_specified ? aws_vpn_connection.tunnel_preshared[0].id : aws_vpn_connection.default[0].id
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,3 +96,16 @@ output "vpn_connection_tunnel2_vgw_inside_address" {
   )
 }
 
+output "transit_gateway_attachment_id" {
+  description = "The transit gateway attachment ID that was generated when attaching this VPN connections."
+  value = element(
+    concat(
+      aws_vpn_connection.default.*.transit_gateway_attachment_id,
+      aws_vpn_connection.tunnel.*.transit_gateway_attachment_id,
+      aws_vpn_connection.preshared.*.transit_gateway_attachment_id,
+      aws_vpn_connection.tunnel_preshared.*.transit_gateway_attachment_id,
+      [""],
+    ),
+    0,
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@ variable "vpn_gateway_id" {
   default     = null
 }
 
-variable "connect_to_transit_gateway" {
-  description = "Connect to a TGW (true) rather than a VPN gateway (false, default)"
-  type        = bool
-  default     = false
-}
 variable "transit_gateway_id" {
   description = "The ID of the Transit Gateway."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,18 @@
 variable "vpn_gateway_id" {
   description = "The id of the VPN Gateway."
   type        = string
+  default     = null
+}
+
+variable "connect_to_transit_gateway" {
+  description = "Connect to a TGW (true) rather than a VPN gateway (false, default)"
+  type        = bool
+  default     = false
+}
+variable "transit_gateway_id" {
+  description = "The ID of the Transit Gateway."
+  type        = string
+  default     = null
 }
 
 variable "customer_gateway_id" {
@@ -17,6 +29,7 @@ variable "create_vpn_connection" {
 variable "vpc_id" {
   description = "The id of the VPC where the VPN Gateway lives."
   type        = string
+  default     = null
 }
 
 variable "vpc_subnet_route_table_ids" {


### PR DESCRIPTION
# Description

This adds support for specifying the `transit_gateway_id` so this module can also be used to connect VPN connections to transit gateways. I've chosen to not include the `aws_ec2_transit_gateway_route_table` in this module as this would leak a lot of transit gateway resources into this module. The module now exports the `transit_gateway_attachment_id` so users can pick this up outside the module.

This was also requested in #21 