### PR TITLE
VPN connection additional args

### DIFF
--- a/examples/complete-dual-vpn-gateway/versions.tf
+++ b/examples/complete-dual-vpn-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}

--- a/examples/complete-vpn-connection-transit-gateway/versions.tf
+++ b/examples/complete-vpn-connection-transit-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}

--- a/examples/complete-vpn-gateway-with-static-routes/versions.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}

--- a/examples/complete-vpn-gateway/versions.tf
+++ b/examples/complete-vpn-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}

--- a/examples/minimal-vpn-gateway/versions.tf
+++ b/examples/minimal-vpn-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,48 @@ resource "aws_vpn_connection" "default" {
 
   static_routes_only = var.vpn_connection_static_routes_only
 
+  tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
+  tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers
+
+  tunnel1_phase1_encryption_algorithms = var.tunnel1_phase1_encryption_algorithms
+  tunnel2_phase1_encryption_algorithms = var.tunnel2_phase1_encryption_algorithms
+
+  tunnel1_phase1_integrity_algorithms = var.tunnel1_phase1_integrity_algorithms
+  tunnel2_phase1_integrity_algorithms = var.tunnel2_phase1_integrity_algorithms
+
+  tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
+  tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
+
+  tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
+  tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
+
+  tunnel1_phase2_dh_group_numbers = var.tunnel1_phase2_dh_group_numbers
+  tunnel2_phase2_dh_group_numbers = var.tunnel2_phase2_dh_group_numbers
+
+  tunnel1_phase2_encryption_algorithms = var.tunnel1_phase2_encryption_algorithms
+  tunnel2_phase2_encryption_algorithms = var.tunnel2_phase2_encryption_algorithms
+
+  tunnel1_phase2_integrity_algorithms = var.tunnel1_phase2_integrity_algorithms
+  tunnel2_phase2_integrity_algorithms = var.tunnel2_phase2_integrity_algorithms
+
+  tunnel1_phase2_lifetime_seconds = var.tunnel1_phase2_lifetime_seconds
+  tunnel2_phase2_lifetime_seconds = var.tunnel2_phase2_lifetime_seconds
+
+  tunnel1_rekey_fuzz_percentage = var.tunnel1_rekey_fuzz_percentage
+  tunnel2_rekey_fuzz_percentage = var.tunnel2_rekey_fuzz_percentage
+
+  tunnel1_rekey_margin_time_seconds = var.tunnel1_rekey_margin_time_seconds
+  tunnel2_rekey_margin_time_seconds = var.tunnel2_rekey_margin_time_seconds
+
+  tunnel1_replay_window_size = var.tunnel1_replay_window_size
+  tunnel2_replay_window_size = var.tunnel2_replay_window_size
+
+  tunnel1_startup_action = var.tunnel1_startup_action
+  tunnel2_startup_action = var.tunnel2_startup_action
+
+  tunnel1_ike_versions = var.tunnel1_ike_versions
+  tunnel2_ike_versions = var.tunnel2_ike_versions
+
   tags = merge(
     {
       "Name" = local.name_tag
@@ -49,6 +91,48 @@ resource "aws_vpn_connection" "tunnel" {
   tunnel1_inside_cidr = var.tunnel1_inside_cidr
   tunnel2_inside_cidr = var.tunnel2_inside_cidr
 
+  tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
+  tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers
+
+  tunnel1_phase1_encryption_algorithms = var.tunnel1_phase1_encryption_algorithms
+  tunnel2_phase1_encryption_algorithms = var.tunnel2_phase1_encryption_algorithms
+
+  tunnel1_phase1_integrity_algorithms = var.tunnel1_phase1_integrity_algorithms
+  tunnel2_phase1_integrity_algorithms = var.tunnel2_phase1_integrity_algorithms
+
+  tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
+  tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
+
+  tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
+  tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
+
+  tunnel1_phase2_dh_group_numbers = var.tunnel1_phase2_dh_group_numbers
+  tunnel2_phase2_dh_group_numbers = var.tunnel2_phase2_dh_group_numbers
+
+  tunnel1_phase2_encryption_algorithms = var.tunnel1_phase2_encryption_algorithms
+  tunnel2_phase2_encryption_algorithms = var.tunnel2_phase2_encryption_algorithms
+
+  tunnel1_phase2_integrity_algorithms = var.tunnel1_phase2_integrity_algorithms
+  tunnel2_phase2_integrity_algorithms = var.tunnel2_phase2_integrity_algorithms
+
+  tunnel1_phase2_lifetime_seconds = var.tunnel1_phase2_lifetime_seconds
+  tunnel2_phase2_lifetime_seconds = var.tunnel2_phase2_lifetime_seconds
+
+  tunnel1_rekey_fuzz_percentage = var.tunnel1_rekey_fuzz_percentage
+  tunnel2_rekey_fuzz_percentage = var.tunnel2_rekey_fuzz_percentage
+
+  tunnel1_rekey_margin_time_seconds = var.tunnel1_rekey_margin_time_seconds
+  tunnel2_rekey_margin_time_seconds = var.tunnel2_rekey_margin_time_seconds
+
+  tunnel1_replay_window_size = var.tunnel1_replay_window_size
+  tunnel2_replay_window_size = var.tunnel2_replay_window_size
+
+  tunnel1_startup_action = var.tunnel1_startup_action
+  tunnel2_startup_action = var.tunnel2_startup_action
+
+  tunnel1_ike_versions = var.tunnel1_ike_versions
+  tunnel2_ike_versions = var.tunnel2_ike_versions
+
   tags = merge(
     {
       "Name" = local.name_tag
@@ -61,7 +145,7 @@ resource "aws_vpn_connection" "tunnel" {
 resource "aws_vpn_connection" "preshared" {
   count = var.create_vpn_connection && local.create_tunner_with_preshared_key_only ? 1 : 0
 
-  vpn_gateway_id     = var.vpn_gateway_id
+  #vpn_gateway_id     = var.vpn_gateway_id
   transit_gateway_id = var.transit_gateway_id
 
   customer_gateway_id = var.customer_gateway_id
@@ -71,6 +155,48 @@ resource "aws_vpn_connection" "preshared" {
 
   tunnel1_preshared_key = var.tunnel1_preshared_key
   tunnel2_preshared_key = var.tunnel2_preshared_key
+
+  tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
+  tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers
+
+  tunnel1_phase1_encryption_algorithms = var.tunnel1_phase1_encryption_algorithms
+  tunnel2_phase1_encryption_algorithms = var.tunnel2_phase1_encryption_algorithms
+
+  tunnel1_phase1_integrity_algorithms = var.tunnel1_phase1_integrity_algorithms
+  tunnel2_phase1_integrity_algorithms = var.tunnel2_phase1_integrity_algorithms
+
+  tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
+  tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
+
+  tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
+  tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
+
+  tunnel1_phase2_dh_group_numbers = var.tunnel1_phase2_dh_group_numbers
+  tunnel2_phase2_dh_group_numbers = var.tunnel2_phase2_dh_group_numbers
+
+  tunnel1_phase2_encryption_algorithms = var.tunnel1_phase2_encryption_algorithms
+  tunnel2_phase2_encryption_algorithms = var.tunnel2_phase2_encryption_algorithms
+
+  tunnel1_phase2_integrity_algorithms = var.tunnel1_phase2_integrity_algorithms
+  tunnel2_phase2_integrity_algorithms = var.tunnel2_phase2_integrity_algorithms
+
+  tunnel1_phase2_lifetime_seconds = var.tunnel1_phase2_lifetime_seconds
+  tunnel2_phase2_lifetime_seconds = var.tunnel2_phase2_lifetime_seconds
+
+  tunnel1_rekey_fuzz_percentage = var.tunnel1_rekey_fuzz_percentage
+  tunnel2_rekey_fuzz_percentage = var.tunnel2_rekey_fuzz_percentage
+
+  tunnel1_rekey_margin_time_seconds = var.tunnel1_rekey_margin_time_seconds
+  tunnel2_rekey_margin_time_seconds = var.tunnel2_rekey_margin_time_seconds
+
+  tunnel1_replay_window_size = var.tunnel1_replay_window_size
+  tunnel2_replay_window_size = var.tunnel2_replay_window_size
+
+  tunnel1_startup_action = var.tunnel1_startup_action
+  tunnel2_startup_action = var.tunnel2_startup_action
+
+  tunnel1_ike_versions = var.tunnel1_ike_versions
+  tunnel2_ike_versions = var.tunnel2_ike_versions
 
   tags = merge(
     {
@@ -97,6 +223,48 @@ resource "aws_vpn_connection" "tunnel_preshared" {
 
   tunnel1_preshared_key = var.tunnel1_preshared_key
   tunnel2_preshared_key = var.tunnel2_preshared_key
+
+  tunnel1_phase1_dh_group_numbers = var.tunnel1_phase1_dh_group_numbers
+  tunnel2_phase1_dh_group_numbers = var.tunnel2_phase1_dh_group_numbers
+
+  tunnel1_phase1_encryption_algorithms = var.tunnel1_phase1_encryption_algorithms
+  tunnel2_phase1_encryption_algorithms = var.tunnel2_phase1_encryption_algorithms
+
+  tunnel1_phase1_integrity_algorithms = var.tunnel1_phase1_integrity_algorithms
+  tunnel2_phase1_integrity_algorithms = var.tunnel2_phase1_integrity_algorithms
+
+  tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
+  tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
+
+  tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
+  tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
+
+  tunnel1_phase2_dh_group_numbers = var.tunnel1_phase2_dh_group_numbers
+  tunnel2_phase2_dh_group_numbers = var.tunnel2_phase2_dh_group_numbers
+
+  tunnel1_phase2_encryption_algorithms = var.tunnel1_phase2_encryption_algorithms
+  tunnel2_phase2_encryption_algorithms = var.tunnel2_phase2_encryption_algorithms
+
+  tunnel1_phase2_integrity_algorithms = var.tunnel1_phase2_integrity_algorithms
+  tunnel2_phase2_integrity_algorithms = var.tunnel2_phase2_integrity_algorithms
+
+  tunnel1_phase2_lifetime_seconds = var.tunnel1_phase2_lifetime_seconds
+  tunnel2_phase2_lifetime_seconds = var.tunnel2_phase2_lifetime_seconds
+
+  tunnel1_rekey_fuzz_percentage = var.tunnel1_rekey_fuzz_percentage
+  tunnel2_rekey_fuzz_percentage = var.tunnel2_rekey_fuzz_percentage
+
+  tunnel1_rekey_margin_time_seconds = var.tunnel1_rekey_margin_time_seconds
+  tunnel2_rekey_margin_time_seconds = var.tunnel2_rekey_margin_time_seconds
+
+  tunnel1_replay_window_size = var.tunnel1_replay_window_size
+  tunnel2_replay_window_size = var.tunnel2_replay_window_size
+
+  tunnel1_startup_action = var.tunnel1_startup_action
+  tunnel2_startup_action = var.tunnel2_startup_action
+
+  tunnel1_ike_versions = var.tunnel1_ike_versions
+  tunnel2_ike_versions = var.tunnel2_ike_versions
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,7 @@ resource "aws_vpn_connection" "tunnel" {
 resource "aws_vpn_connection" "preshared" {
   count = var.create_vpn_connection && local.create_tunnel_with_preshared_key_only ? 1 : 0
 
-  #vpn_gateway_id     = var.vpn_gateway_id
+  vpn_gateway_id     = var.vpn_gateway_id
   transit_gateway_id = var.transit_gateway_id
 
   customer_gateway_id = var.customer_gateway_id

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,9 @@ resource "aws_vpn_connection" "tunnel" {
   tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
   tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
 
+  tunnel1_dpd_timeout_seconds = var.tunnel1_dpd_timeout_seconds
+  tunnel2_dpd_timeout_seconds = var.tunnel2_dpd_timeout_seconds
+
   tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
   tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
 

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,8 @@ locals {
   tunnel_details_not_specified = local.internal_cidr_not_provided && local.preshared_key_not_provided
   tunnel_details_specified     = local.internal_cidr_provided && local.preshared_key_provided
 
-  create_tunner_with_internal_cidr_only = local.internal_cidr_provided && local.preshared_key_not_provided
-  create_tunner_with_preshared_key_only = local.internal_cidr_not_provided && local.preshared_key_provided
+  create_tunnel_with_internal_cidr_only = local.internal_cidr_provided && local.preshared_key_not_provided
+  create_tunnel_with_preshared_key_only = local.internal_cidr_not_provided && local.preshared_key_provided
 
   connection_identifier = var.connect_to_transit_gateway ? "TGW ${var.transit_gateway_id}" : "VPC ${var.vpc_id}"
   name_tag              = "VPN Connection between ${local.connection_identifier} and Customer Gateway ${var.customer_gateway_id}"
@@ -78,7 +78,7 @@ resource "aws_vpn_connection" "default" {
 
 ### Tunnel Inside CIDR only
 resource "aws_vpn_connection" "tunnel" {
-  count = var.create_vpn_connection && local.create_tunner_with_internal_cidr_only ? 1 : 0
+  count = var.create_vpn_connection && local.create_tunnel_with_internal_cidr_only ? 1 : 0
 
   vpn_gateway_id     = var.vpn_gateway_id
   transit_gateway_id = var.transit_gateway_id
@@ -143,7 +143,7 @@ resource "aws_vpn_connection" "tunnel" {
 
 ### Preshared Key only
 resource "aws_vpn_connection" "preshared" {
-  count = var.create_vpn_connection && local.create_tunner_with_preshared_key_only ? 1 : 0
+  count = var.create_vpn_connection && local.create_tunnel_with_preshared_key_only ? 1 : 0
 
   #vpn_gateway_id     = var.vpn_gateway_id
   transit_gateway_id = var.transit_gateway_id
@@ -291,7 +291,7 @@ resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
 resource "aws_vpn_connection_route" "default" {
   count = var.create_vpn_connection && var.vpn_connection_static_routes_only && ! var.connect_to_transit_gateway ? length(var.vpn_connection_static_routes_destinations) : 0
 
-  vpn_connection_id = local.create_tunner_with_internal_cidr_only ? aws_vpn_connection.tunnel[0].id : local.create_tunner_with_preshared_key_only ? aws_vpn_connection.preshared[0].id : local.tunnel_details_specified ? aws_vpn_connection.tunnel_preshared[0].id : aws_vpn_connection.default[0].id
+  vpn_connection_id = local.create_tunnel_with_internal_cidr_only ? aws_vpn_connection.tunnel[0].id : local.create_tunnel_with_preshared_key_only ? aws_vpn_connection.preshared[0].id : local.tunnel_details_specified ? aws_vpn_connection.tunnel_preshared[0].id : aws_vpn_connection.default[0].id
 
   destination_cidr_block = element(var.vpn_connection_static_routes_destinations, count.index)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,144 @@ variable "connect_to_transit_gateway" {
   type        = bool
   default     = false
 }
+
+variable "tunnel1_phase1_dh_group_numbers" {
+  description = "(Optional) List of one or more Diffie-Hellman group numbers that are permitted for the first VPN tunnel for phase 1 IKE negotiations. Valid values are 2 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24"
+  type        = list(number)
+  default     = null
+}
+variable "tunnel2_phase1_dh_group_numbers" {
+  description = "(Optional) List of one or more Diffie-Hellman group numbers that are permitted for the second VPN tunnel for phase 1 IKE negotiations. Valid values are 2 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24"
+  type        = list(number)
+  default     = null
+}
+variable "tunnel1_phase1_encryption_algorithms" {
+  description = "(Optional) List of one or more encryption algorithms that are permitted for the first VPN tunnel for phase 1 IKE negotiations. Valid values are AES128 | AES256 | AES128-GCM-16 | AES256-GCM-16"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel2_phase1_encryption_algorithms" {
+  description = "(Optional) List of one or more encryption algorithms that are permitted for the second VPN tunnel for phase 1 IKE negotiations. Valid values are AES128 | AES256 | AES128-GCM-16 | AES256-GCM-16"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel1_phase1_integrity_algorithms" {
+  description = "(Optional) One or more integrity algorithms that are permitted for the first VPN tunnel for phase 1 IKE negotiations. Valid values are SHA1 | SHA2-256 | SHA2-384 | SHA2-512"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel2_phase1_integrity_algorithms" {
+  description = "(Optional) One or more integrity algorithms that are permitted for the second VPN tunnel for phase 1 IKE negotiations. Valid values are SHA1 | SHA2-256 | SHA2-384 | SHA2-512"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel1_phase1_lifetime_seconds" {
+  description = "(Optional, Default 28800) The lifetime for phase 1 of the IKE negotiation for the first VPN tunnel, in seconds. Valid value is between 900 and 28800"
+  type        = number
+  default     = null
+}
+variable "tunnel2_phase1_lifetime_seconds" {
+  description = "(Optional, Default 28800) The lifetime for phase 1 of the IKE negotiation for the second VPN tunnel, in seconds. Valid value is between 900 and 28800."
+  type        = number
+  default     = null
+}
+variable "tunnel1_dpd_timeout_action" {
+  description = "(Optional, Default clear) The action to take after DPD timeout occurs for the first VPN tunnel. Specify restart to restart the IKE initiation. Specify clear to end the IKE session. Valid values are clear | none | restart"
+  type        = string
+  default     = null
+}
+variable "tunnel2_dpd_timeout_action" {
+  description = "(Optional, Default clear) The action to take after DPD timeout occurs for the second VPN tunnel. Specify restart to restart the IKE initiation. Specify clear to end the IKE session. Valid values are clear | none | restart"
+  type        = string
+  default     = null
+}
+variable "tunnel1_phase2_dh_group_numbers" {
+  description = "(Optional) List of one or more Diffie-Hellman group numbers that are permitted for the first VPN tunnel for phase 2 IKE negotiations. Valid values are 2 | 5 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24"
+  type        = list(number)
+  default     = null
+}
+variable "tunnel2_phase2_dh_group_numbers" {
+  description = "(Optional) List of one or more Diffie-Hellman group numbers that are permitted for the second VPN tunnel for phase 2 IKE negotiations. Valid values are 2 | 5 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24"
+  type        = list(number)
+  default     = null
+}
+variable "tunnel1_phase2_encryption_algorithms" {
+  description = "(Optional) List of one or more encryption algorithms that are permitted for the first VPN tunnel for phase 2 IKE negotiations. Valid values are AES128 | AES256 | AES128-GCM-16 | AES256-GCM-16"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel2_phase2_encryption_algorithms" {
+  description = "(Optional) List of one or more encryption algorithms that are permitted for the second VPN tunnel for phase 2 IKE negotiations. Valid values are AES128 | AES256 | AES128-GCM-16 | AES256-GCM-16"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel1_phase2_integrity_algorithms" {
+  description = "(Optional) List of one or more integrity algorithms that are permitted for the first VPN tunnel for phase 2 IKE negotiations. Valid values are SHA1 | SHA2-256 | SHA2-384 | SHA2-512"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel2_phase2_integrity_algorithms" {
+  description = "(Optional) List of one or more integrity algorithms that are permitted for the second VPN tunnel for phase 2 IKE negotiations. Valid values are SHA1 | SHA2-256 | SHA2-384 | SHA2-512"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel1_phase2_lifetime_seconds" {
+  description = "(Optional, Default 3600) The lifetime for phase 2 of the IKE negotiation for the first VPN tunnel, in seconds. Valid value is between 900 and 3600"
+  type        = number
+  default     = null
+}
+variable "tunnel2_phase2_lifetime_seconds" {
+  description = "(Optional, Default 3600) The lifetime for phase 2 of the IKE negotiation for the second VPN tunnel, in seconds. Valid value is between 900 and 3600"
+  type        = number
+  default     = null
+}
+variable "tunnel1_rekey_fuzz_percentage" {
+  description = "(Optional, Default 100) The percentage of the rekey window for the first VPN tunnel (determined by tunnel1_rekey_margin_time_seconds) during which the rekey time is randomly selected. Valid value is between 0 and 100"
+  type        = number
+  default     = null
+}
+variable "tunnel2_rekey_fuzz_percentage" {
+  description = "(Optional, Default 100) The percentage of the rekey window for the second VPN tunnel (determined by tunnel1_rekey_margin_time_seconds) during which the rekey time is randomly selected. Valid value is between 0 and 100"
+  type        = number
+  default     = null
+}
+variable "tunnel1_rekey_margin_time_seconds" {
+  description = "(Optional, Default 540) The margin time, in seconds, before the phase 2 lifetime expires, during which the AWS side of the first VPN connection performs an IKE rekey. The exact time of the rekey is randomly selected based on the value for tunnel1_rekey_fuzz_percentage. Valid value is between 60 and half of tunnel1_phase2_lifetime_seconds"
+  type        = number
+  default     = null
+}
+variable "tunnel2_rekey_margin_time_seconds" {
+  description = "(Optional, Default 540) The margin time, in seconds, before the phase 2 lifetime expires, during which the AWS side of the second VPN connection performs an IKE rekey. The exact time of the rekey is randomly selected based on the value for tunnel2_rekey_fuzz_percentage. Valid value is between 60 and half of tunnel2_phase2_lifetime_seconds"
+  type        = number
+  default     = null
+}
+variable "tunnel1_replay_window_size" {
+  description = "(Optional, Default 1024) The number of packets in an IKE replay window for the first VPN tunnel. Valid value is between 64 and 2048."
+  type        = number
+  default     = null
+}
+variable "tunnel2_replay_window_size" {
+  description = "(Optional, Default 1024) The number of packets in an IKE replay window for the second VPN tunnel. Valid value is between 64 and 2048."
+  type        = number
+  default     = null
+}
+variable "tunnel1_startup_action" {
+  description = "(Optional, Default add) The action to take when the establishing the tunnel for the first VPN connection. By default, your customer gateway device must initiate the IKE negotiation and bring up the tunnel. Specify start for AWS to initiate the IKE negotiation. Valid values are add | start"
+  type        = string
+  default     = null
+}
+variable "tunnel2_startup_action" {
+  description = "(Optional, Default add) The action to take when the establishing the tunnel for the second VPN connection. By default, your customer gateway device must initiate the IKE negotiation and bring up the tunnel. Specify start for AWS to initiate the IKE negotiation. Valid values are add | start"
+  type        = string
+  default     = null
+}
+variable "tunnel1_ike_versions" {
+  description = "(Optional) The IKE versions that are permitted for the first VPN tunnel. Valid values are ikev1 | ikev2"
+  type        = list(string)
+  default     = null
+}
+variable "tunnel2_ike_versions" {
+  description = "(Optional) The IKE versions that are permitted for the first VPN tunnel. Valid values are ikev1 | ikev2"
+  type        = list(string)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,17 @@ variable "tunnel1_phase1_lifetime_seconds" {
   default     = null
 }
 variable "tunnel2_phase1_lifetime_seconds" {
-  description = "(Optional, Default 28800) The lifetime for phase 1 of the IKE negotiation for the second VPN tunnel, in seconds. Valid value is between 900 and 28800."
+  description = "(Optional, Default 28800) The lifetime for phase 1 of the IKE negotiation for the second VPN tunnel, in seconds. Valid value is between 900 and 28800"
+  type        = number
+  default     = null
+}
+variable "tunnel1_dpd_timeout_seconds" {
+  description = "(Optional, Default 30) The number of seconds after which a DPD timeout occurs for the first VPN tunnel. Valid value is equal or higher than 30"
+  type        = number
+  default     = null
+}
+variable "tunnel2_dpd_timeout_seconds" {
+  description = "(Optional, Default 30) The number of seconds after which a DPD timeout occurs for the second VPN tunnel. Valid value is equal or higher than 30"
   type        = number
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.22"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Introduce new supported variables for `aws_vpn_connection` resources. Default values are set to `null` so this should be backward compatible with older versions.

## Motivation and Context

Current version doesn't allow set those variables and after AWS replaced my VPN tunnel due to some maintenance - terrafrom apply fails. Also should fix #43 

## Breaking Changes

no breaking changes

## How Has This Been Tested?

No thorough testing, I've updated my own environments with this version