### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
 
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ No Modules.
 
 | Name |
 |------|
-| [aws_vpn_connection](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_connection) |
 | [aws_vpn_connection_route](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_connection_route) |
+| [aws_vpn_connection](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_connection) |
 | [aws_vpn_gateway_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_gateway_attachment) |
 | [aws_vpn_gateway_route_propagation](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_gateway_route_propagation) |
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,19 @@ module "tgw" {
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_vpn_connection](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_connection) |
+| [aws_vpn_connection_route](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_connection_route) |
+| [aws_vpn_gateway_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_gateway_attachment) |
+| [aws_vpn_gateway_route_propagation](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/vpn_gateway_route_propagation) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -315,7 +328,6 @@ module "tgw" {
 | vpn\_connection\_tunnel2\_address | A list with the the public IP address of the second VPN tunnel if `create_vpn_connection = true`, or empty otherwise |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address | A list with the the RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side) if `create_vpn_connection = true`, or empty otherwise |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete-dual-vpn-gateway/README.md
+++ b/examples/complete-dual-vpn-gateway/README.md
@@ -35,6 +35,20 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| vpn_gateway | ../../ |  |
+| vpn_gateway2 | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/customer_gateway) |
+
 ## Inputs
 
 No input.
@@ -57,5 +71,4 @@ No input.
 | vpn\_gateway\_vpn\_connection\_tunnel2\_address | n/a |
 | vpn\_gateway\_vpn\_connection\_tunnel2\_cgw\_inside\_address | n/a |
 | vpn\_gateway\_vpn\_connection\_tunnel2\_vgw\_inside\_address | n/a |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -40,8 +40,8 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name |
 |------|
-| [aws_ec2_transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/ec2_transit_gateway) |
 | [aws_ec2_transit_gateway_vpc_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/ec2_transit_gateway_vpc_attachment) |
+| [aws_ec2_transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/ec2_transit_gateway) |
 
 ## Inputs
 

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -28,6 +28,21 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| vpn_gateway_1 | ../../ |  |
+| vpn_gateway_2 | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ec2_transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/ec2_transit_gateway) |
+| [aws_ec2_transit_gateway_vpc_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/ec2_transit_gateway_vpc_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -47,5 +62,4 @@ Run `terraform destroy` when you don't need these resources.
 | vpn\_connection\_tunnel2\_address | n/a |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address | n/a |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address | n/a |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-gateway-with-static-routes/README.md
+++ b/examples/complete-vpn-gateway-with-static-routes/README.md
@@ -30,6 +30,19 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| vpn_gateway | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/customer_gateway) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -48,5 +61,4 @@ Run `terraform destroy` when you don't need these resources.
 | vpn\_connection\_tunnel2\_address | n/a |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address | n/a |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address | n/a |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-gateway/README.md
+++ b/examples/complete-vpn-gateway/README.md
@@ -30,6 +30,19 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| vpn_gateway | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/customer_gateway) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -47,5 +60,4 @@ Run `terraform destroy` when you don't need these resources.
 | vpn\_connection\_tunnel2\_address | n/a |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address | n/a |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address | n/a |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/minimal-vpn-gateway/README.md
+++ b/examples/minimal-vpn-gateway/README.md
@@ -30,6 +30,19 @@ Run `terraform destroy` when you don't need these resources.
 |------|---------|
 | aws | >= 3.22 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| vpn_gateway | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.22/docs/resources/customer_gateway) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -47,5 +60,4 @@ Run `terraform destroy` when you don't need these resources.
 | vpn\_connection\_tunnel2\_address | n/a |
 | vpn\_connection\_tunnel2\_cgw\_inside\_address | n/a |
 | vpn\_connection\_tunnel2\_vgw\_inside\_address | n/a |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -278,21 +278,21 @@ resource "aws_vpn_connection" "tunnel_preshared" {
 }
 
 resource "aws_vpn_gateway_attachment" "default" {
-  count = var.create_vpn_connection && var.create_vpn_gateway_attachment && !var.connect_to_transit_gateway ? 1 : 0
+  count = var.create_vpn_connection && var.create_vpn_gateway_attachment && ! var.connect_to_transit_gateway ? 1 : 0
 
   vpc_id         = var.vpc_id
   vpn_gateway_id = var.vpn_gateway_id
 }
 
 resource "aws_vpn_gateway_route_propagation" "private_subnets_vpn_routing" {
-  count = var.create_vpn_connection && !var.connect_to_transit_gateway ? var.vpc_subnet_route_table_count : 0
+  count = var.create_vpn_connection && ! var.connect_to_transit_gateway ? var.vpc_subnet_route_table_count : 0
 
   vpn_gateway_id = var.vpn_gateway_id
   route_table_id = element(var.vpc_subnet_route_table_ids, count.index)
 }
 
 resource "aws_vpn_connection_route" "default" {
-  count = var.create_vpn_connection && var.vpn_connection_static_routes_only && !var.connect_to_transit_gateway ? length(var.vpn_connection_static_routes_destinations) : 0
+  count = var.create_vpn_connection && var.vpn_connection_static_routes_only && ! var.connect_to_transit_gateway ? length(var.vpn_connection_static_routes_destinations) : 0
 
   vpn_connection_id = local.create_tunnel_with_internal_cidr_only ? aws_vpn_connection.tunnel[0].id : local.create_tunnel_with_preshared_key_only ? aws_vpn_connection.preshared[0].id : local.tunnel_details_specified ? aws_vpn_connection.tunnel_preshared[0].id : aws_vpn_connection.default[0].id
 


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
