### PR TITLE
feat: Added dpd_timeout_seconds variable to the "default" tunnel resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,9 @@ resource "aws_vpn_connection" "default" {
   tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
   tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
 
+  tunnel1_dpd_timeout_seconds = var.tunnel1_dpd_timeout_seconds
+  tunnel2_dpd_timeout_seconds = var.tunnel2_dpd_timeout_seconds
+
   tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
   tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
 


### PR DESCRIPTION
Exposed the tunnel1_dpd_timeout_seconds and tunnel2_dpd_timeout_seconds
module parameters to the "default" AWS managed aws_vpn_connection resource.

## Description
The change adds the `tunnel1_dpd_timeout_seconds` and `tunnel2_dpd_timeout_seconds`\
parameters to the default aws_vpn_connection resource as its appears to have been missed.

## Motivation and Context
This was added because it appears to have been missed off PR #46 

## Breaking Changes
None that I have discovered.

## How Has This Been Tested?
I have tested this change against my own implementation using this module.
