### PR TITLE
Set output to sensitive for vpn_connection_customer_gateway_configuration

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -122,6 +122,7 @@ output "vpn_connection_customer_gateway_configuration" {
     ),
     0,
   )
+  sensitive = true
 }
 
 output "tunnel1_preshared_key" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change sets the output of `vpn_connection_customer_gateway_configuration` to sensitive.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The latest AWS provider flags the data in this output as secret due to the preshared keys in it and results in an error on a plan.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ✅ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
