### PR TITLE
feat: Add outside_ip_address_type argument to aws_vpn_connection resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ No modules.
 | <a name="input_customer_gateway_id"></a> [customer\_gateway\_id](#input\_customer\_gateway\_id) | The id of the Customer Gateway. | `string` | n/a | yes |
 | <a name="input_local_ipv4_network_cidr"></a> [local\_ipv4\_network\_cidr](#input\_local\_ipv4\_network\_cidr) | (Optional) The IPv4 CIDR on the customer gateway (on-premises) side of the VPN connection. | `string` | `null` | no |
 | <a name="input_local_ipv6_network_cidr"></a> [local\_ipv6\_network\_cidr](#input\_local\_ipv6\_network\_cidr) | (Optional) The IPv6 CIDR on the customer gateway (on-premises) side of the VPN connection. | `string` | `null` | no |
+| <a name="input_outside_ip_address_type"></a> [outside\_ip\_address\_type](#input\_outside\_ip\_address\_type) | (Optional) Indicates if a Public S2S VPN or Private S2S VPN over AWS Direct Connect. | `string` | `"PublicIpv4"` | no |
 | <a name="input_remote_ipv4_network_cidr"></a> [remote\_ipv4\_network\_cidr](#input\_remote\_ipv4\_network\_cidr) | (Optional) The IPv4 CIDR on the AWS side of the VPN connection. | `string` | `null` | no |
 | <a name="input_remote_ipv6_network_cidr"></a> [remote\_ipv6\_network\_cidr](#input\_remote\_ipv6\_network\_cidr) | (Optional) The IPv6 CIDR on AWS side of the VPN connection. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Set of tags to be added to the VPN Connection resource (only if `create_vpn_connection = true`). | `map(string)` | `{}` | no |

--- a/examples/minimal-private-vpn-gateway/README.md
+++ b/examples/minimal-private-vpn-gateway/README.md
@@ -1,0 +1,63 @@
+# Minimal VPN Gateway setup
+
+Configuration in this directory creates set of VPN Gateway related resources, excluding a VPN Connection, which may be sufficient for staging or production environment (look into [complete-vpn-gateway](../complete-vpn-gateway) for more complete setup).
+
+There will not be a VPN Connection created linking a (pre-existing) VPN Gateway in a VPC to a (pre-existing) Customer Gateway.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpn_gateway"></a> [vpn\_gateway](#module\_vpn\_gateway) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_customer_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/customer_gateway) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_vpc_private_subnets"></a> [vpc\_private\_subnets](#input\_vpc\_private\_subnets) | List of private subnets | `list(string)` | <pre>[<br>  "10.10.11.0/24",<br>  "10.10.12.0/24",<br>  "10.10.13.0/24"<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_vpn_connection_id"></a> [vpn\_connection\_id](#output\_vpn\_connection\_id) | VPN id |
+| <a name="output_vpn_connection_tunnel1_address"></a> [vpn\_connection\_tunnel1\_address](#output\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
+| <a name="output_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |
+| <a name="output_vpn_connection_tunnel1_vgw_inside_address"></a> [vpn\_connection\_tunnel1\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_vgw\_inside\_address) | Tunnel1 VGW address |
+| <a name="output_vpn_connection_tunnel2_address"></a> [vpn\_connection\_tunnel2\_address](#output\_vpn\_connection\_tunnel2\_address) | Tunnel2 address |
+| <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | Tunnel2 CGW address |
+| <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | Tunnel2 VGW address |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/minimal-private-vpn-gateway/main.tf
+++ b/examples/minimal-private-vpn-gateway/main.tf
@@ -1,0 +1,51 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "vpn_gateway" {
+  source = "../../"
+
+  create_vpn_connection = false
+
+  vpn_gateway_id      = module.vpc.vgw_id
+  customer_gateway_id = aws_customer_gateway.main.id
+
+  vpc_id                       = module.vpc.vpc_id
+  vpc_subnet_route_table_ids   = module.vpc.private_route_table_ids
+  vpc_subnet_route_table_count = length(var.vpc_private_subnets)
+
+  outside_ip_address_type = "PrivateIpv4"
+}
+
+resource "aws_customer_gateway" "main" {
+  bgp_asn    = 65000
+  ip_address = "172.83.124.12"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = "minimal-vpn-gateway"
+  }
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = "minimal-vpn-gateway"
+
+  cidr = "10.10.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  public_subnets  = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
+  private_subnets = var.vpc_private_subnets
+
+  enable_nat_gateway = false
+
+  enable_vpn_gateway = true
+
+  tags = {
+    Owner       = "user"
+    Environment = "staging"
+    Name        = "complete"
+  }
+}

--- a/examples/minimal-private-vpn-gateway/outputs.tf
+++ b/examples/minimal-private-vpn-gateway/outputs.tf
@@ -1,0 +1,34 @@
+output "vpn_connection_id" {
+  description = "VPN id"
+  value       = module.vpn_gateway.vpn_connection_id
+}
+
+output "vpn_connection_tunnel1_address" {
+  description = "Tunnel1 address"
+  value       = module.vpn_gateway.vpn_connection_tunnel1_address
+}
+
+output "vpn_connection_tunnel1_cgw_inside_address" {
+  description = "Tunnel1 CGW address"
+  value       = module.vpn_gateway.vpn_connection_tunnel1_cgw_inside_address
+}
+
+output "vpn_connection_tunnel1_vgw_inside_address" {
+  description = "Tunnel1 VGW address"
+  value       = module.vpn_gateway.vpn_connection_tunnel1_vgw_inside_address
+}
+
+output "vpn_connection_tunnel2_address" {
+  description = "Tunnel2 address"
+  value       = module.vpn_gateway.vpn_connection_tunnel2_address
+}
+
+output "vpn_connection_tunnel2_cgw_inside_address" {
+  description = "Tunnel2 CGW address"
+  value       = module.vpn_gateway.vpn_connection_tunnel2_cgw_inside_address
+}
+
+output "vpn_connection_tunnel2_vgw_inside_address" {
+  description = "Tunnel2 VGW address"
+  value       = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
+}

--- a/examples/minimal-private-vpn-gateway/variables.tf
+++ b/examples/minimal-private-vpn-gateway/variables.tf
@@ -1,0 +1,5 @@
+variable "vpc_private_subnets" {
+  description = "List of private subnets"
+  type        = list(string)
+  default     = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
+}

--- a/examples/minimal-private-vpn-gateway/versions.tf
+++ b/examples/minimal-private-vpn-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.31"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.43"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,8 @@ resource "aws_vpn_connection" "default" {
   local_ipv6_network_cidr  = var.local_ipv6_network_cidr
   remote_ipv6_network_cidr = var.remote_ipv6_network_cidr
 
+  outside_ip_address_type = var.outside_ip_address_type
+
   tags = merge(
     {
       "Name" = local.name_tag
@@ -155,6 +157,8 @@ resource "aws_vpn_connection" "tunnel" {
   local_ipv6_network_cidr  = var.local_ipv6_network_cidr
   remote_ipv6_network_cidr = var.remote_ipv6_network_cidr
 
+  outside_ip_address_type = var.outside_ip_address_type
+
   tags = merge(
     {
       "Name" = local.name_tag
@@ -227,6 +231,8 @@ resource "aws_vpn_connection" "preshared" {
 
   local_ipv6_network_cidr  = var.local_ipv6_network_cidr
   remote_ipv6_network_cidr = var.remote_ipv6_network_cidr
+
+  outside_ip_address_type = var.outside_ip_address_type
 
   tags = merge(
     {
@@ -303,6 +309,8 @@ resource "aws_vpn_connection" "tunnel_preshared" {
 
   local_ipv6_network_cidr  = var.local_ipv6_network_cidr
   remote_ipv6_network_cidr = var.remote_ipv6_network_cidr
+
+  outside_ip_address_type = var.outside_ip_address_type
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -306,3 +306,9 @@ variable "remote_ipv6_network_cidr" {
   type        = string
   default     = null
 }
+
+variable "outside_ip_address_type" {
+  description = "(Optional) Indicates if a Public S2S VPN or Private S2S VPN over AWS Direct Connect."
+  type        = string
+  default     = "PublicIpv4"
+}


### PR DESCRIPTION
## Description
Add the argument **outside_ip_address_type** to vpn resources

## Motivation and Context
Since the release of this [new](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-aws-site-to-site-vpn-private-ip-vpns/) feature it's now possible to create a priate s2s vpn over direct connect.

This PR aim to provide this feature but keep the default value to public in order to avoid disturbance for existing connections.

A new minimal example with this feature turned on has been added.

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
