### PR TITLE
feat!: Update supported Terraform min version to v1.0+ and AWS provider to v4.0+

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-comment: >
+            I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-inactive-days: '30'
+          pr-comment: >
+            I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-inactive-days: '30'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.6
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,11 +17,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.8.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -32,18 +32,18 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
@@ -51,7 +51,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
@@ -62,17 +62,17 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,6 @@ name: Pre-Commit
 on:
   pull_request:
     branches:
-      - main
       - master
 
 env:
@@ -36,7 +35,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.0
+        uses: clowdhaus/terraform-min-max@v1.2.1
         with:
           directory: ${{ matrix.directory }}
 
@@ -69,10 +68,11 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.0
+        uses: clowdhaus/terraform-min-max@v1.2.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          install-hcledit: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
       - master
     paths:
       - '**/*.tpl'

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.1
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -243,14 +243,14 @@ module "tgw" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/complete-dual-vpn-gateway/README.md
+++ b/examples/complete-dual-vpn-gateway/README.md
@@ -26,14 +26,14 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/complete-dual-vpn-gateway/versions.tf
+++ b/examples/complete-dual-vpn-gateway/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -19,14 +19,14 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/complete-vpn-connection-transit-gateway/versions.tf
+++ b/examples/complete-vpn-connection-transit-gateway/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/complete-vpn-gateway-with-static-routes/README.md
+++ b/examples/complete-vpn-gateway-with-static-routes/README.md
@@ -21,14 +21,14 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/complete-vpn-gateway-with-static-routes/versions.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/complete-vpn-gateway/README.md
+++ b/examples/complete-vpn-gateway/README.md
@@ -21,14 +21,14 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/complete-vpn-gateway/versions.tf
+++ b/examples/complete-vpn-gateway/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/minimal-vpn-gateway/README.md
+++ b/examples/minimal-vpn-gateway/README.md
@@ -21,14 +21,14 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 

--- a/examples/minimal-vpn-gateway/versions.tf
+++ b/examples/minimal-vpn-gateway/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,126 +1,99 @@
 output "vpn_connection_id" {
   description = "A list with the VPN Connection ID if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.id,
-      aws_vpn_connection.tunnel.*.id,
-      aws_vpn_connection.preshared.*.id,
-      aws_vpn_connection.tunnel_preshared.*.id,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].id,
+    aws_vpn_connection.tunnel[0].id,
+    aws_vpn_connection.preshared[0].id,
+    aws_vpn_connection.tunnel_preshared[0].id,
+    "")
   )
 }
 
 output "vpn_connection_tunnel1_address" {
   description = "A list with the the public IP address of the first VPN tunnel if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel1_address,
-      aws_vpn_connection.tunnel.*.tunnel1_address,
-      aws_vpn_connection.preshared.*.tunnel1_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel1_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel1_address,
+    aws_vpn_connection.tunnel[0].tunnel1_address,
+    aws_vpn_connection.preshared[0].tunnel1_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel1_address,
+    "")
   )
 }
 
 output "vpn_connection_tunnel1_cgw_inside_address" {
   description = "A list with the the RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel1_cgw_inside_address,
-      aws_vpn_connection.tunnel.*.tunnel1_cgw_inside_address,
-      aws_vpn_connection.preshared.*.tunnel1_cgw_inside_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel1_cgw_inside_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel1_cgw_inside_address,
+    aws_vpn_connection.tunnel[0].tunnel1_cgw_inside_address,
+    aws_vpn_connection.preshared[0].tunnel1_cgw_inside_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel1_cgw_inside_address,
+    "")
   )
 }
 
 output "vpn_connection_tunnel1_vgw_inside_address" {
   description = "A list with the the RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side) if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel1_vgw_inside_address,
-      aws_vpn_connection.tunnel.*.tunnel1_vgw_inside_address,
-      aws_vpn_connection.preshared.*.tunnel1_vgw_inside_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel1_vgw_inside_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel1_vgw_inside_address,
+    aws_vpn_connection.tunnel[0].tunnel1_vgw_inside_address,
+    aws_vpn_connection.preshared[0].tunnel1_vgw_inside_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel1_vgw_inside_address,
+    "")
   )
 }
 
 output "vpn_connection_tunnel2_address" {
   description = "A list with the the public IP address of the second VPN tunnel if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel2_address,
-      aws_vpn_connection.tunnel.*.tunnel2_address,
-      aws_vpn_connection.preshared.*.tunnel2_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel2_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel2_address,
+    aws_vpn_connection.tunnel[0].tunnel2_address,
+    aws_vpn_connection.preshared[0].tunnel2_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel2_address,
+    "")
   )
 }
 
 output "vpn_connection_tunnel2_cgw_inside_address" {
   description = "A list with the the RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side) if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel2_cgw_inside_address,
-      aws_vpn_connection.tunnel.*.tunnel2_cgw_inside_address,
-      aws_vpn_connection.preshared.*.tunnel2_cgw_inside_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel2_cgw_inside_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel2_cgw_inside_address,
+    aws_vpn_connection.tunnel[0].tunnel2_cgw_inside_address,
+    aws_vpn_connection.preshared[0].tunnel2_cgw_inside_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel2_cgw_inside_address,
+    "")
   )
 }
 
 output "vpn_connection_tunnel2_vgw_inside_address" {
   description = "A list with the the RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side) if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.tunnel2_vgw_inside_address,
-      aws_vpn_connection.tunnel.*.tunnel2_vgw_inside_address,
-      aws_vpn_connection.preshared.*.tunnel2_vgw_inside_address,
-      aws_vpn_connection.tunnel_preshared.*.tunnel2_vgw_inside_address,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].tunnel2_vgw_inside_address,
+    aws_vpn_connection.tunnel[0].tunnel2_vgw_inside_address,
+    aws_vpn_connection.preshared[0].tunnel2_vgw_inside_address,
+    aws_vpn_connection.tunnel_preshared[0].tunnel2_vgw_inside_address,
+    "")
   )
 }
 
 output "vpn_connection_transit_gateway_attachment_id" {
   description = "The transit gateway attachment ID that was generated when attaching this VPN connection."
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.transit_gateway_attachment_id,
-      aws_vpn_connection.tunnel.*.transit_gateway_attachment_id,
-      aws_vpn_connection.preshared.*.transit_gateway_attachment_id,
-      aws_vpn_connection.tunnel_preshared.*.transit_gateway_attachment_id,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].transit_gateway_attachment_id,
+    aws_vpn_connection.tunnel[0].transit_gateway_attachment_id,
+    aws_vpn_connection.preshared[0].transit_gateway_attachment_id,
+    aws_vpn_connection.tunnel_preshared[0].transit_gateway_attachment_id,
+    "")
   )
 }
 
 output "vpn_connection_customer_gateway_configuration" {
   description = "The configuration information for the VPN connection's customer gateway (in the native XML format) if `create_vpn_connection = true`, or empty otherwise"
-  value = element(
-    concat(
-      aws_vpn_connection.default.*.customer_gateway_configuration,
-      aws_vpn_connection.tunnel.*.customer_gateway_configuration,
-      aws_vpn_connection.preshared.*.customer_gateway_configuration,
-      aws_vpn_connection.tunnel_preshared.*.customer_gateway_configuration,
-      [""],
-    ),
-    0,
+  value = try(coalesce(
+    aws_vpn_connection.default[0].customer_gateway_configuration,
+    aws_vpn_connection.tunnel[0].customer_gateway_configuration,
+    aws_vpn_connection.preshared[0].customer_gateway_configuration,
+    aws_vpn_connection.tunnel_preshared[0].customer_gateway_configuration,
+    "")
   )
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
## Description

- Update GitHub action versions to use latest. This remove warnings related to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Ensure pre-commit config is aligned with latest
- Add `lock.yml` workflow to automatically lock issues and PRs after 30 days. Theres a lot "Me too" or "I have this issue, when will this get fixed" on really old/stale issues and in order to properly triage, users need to supply their configurations. This workflow is pulled from the AWS provider's repo to force users to fill out a proper issue ticket and keep chatter out of merged PRs or old issues
- Update supported Terraform min version to v1.0+ and AWS provider to v4.0+

## Motivation and Context

- Patch warnings on CI checks to keep output clean
- Focus on new issues and PRs

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request