### PR TITLE
feat: Set `vpn_connection_customer_gateway_configuration` output to `sensitive = true`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -86,6 +86,7 @@ output "vpn_connection_customer_gateway_configuration" {
     aws_vpn_connection.preshared[0].customer_gateway_configuration,
     aws_vpn_connection.tunnel_preshared[0].customer_gateway_configuration,
   "")
+  sensitive = true
 }
 
 output "tunnel1_preshared_key" {


### PR DESCRIPTION
## Description
When creating the VPN gateway the output fails because the `vpn_connection_customer_gateway_configuration` has sensitive values.

```
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 81:
│   81: output "vpn_connection_customer_gateway_configuration" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```

## Motivation and Context
In order for the apply to go through fully, I've set the output value to be sensitive.

Existing issue that mentions several PRs that already fixed the same problem:  fixes #80

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [n/a] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [✓] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [✓] I have executed `pre-commit run -a` on my pull request

