### PR TITLE
feat: Set tunnel PSK outputs to `sensitive = true`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -92,9 +92,11 @@ output "vpn_connection_customer_gateway_configuration" {
 output "tunnel1_preshared_key" {
   description = "The preshared key of the first VPN tunnel."
   value       = var.tunnel1_preshared_key
+  sensitive   = true
 }
 
 output "tunnel2_preshared_key" {
   description = "The preshared key of the second VPN tunnel."
   value       = var.tunnel2_preshared_key
+  sensitive   = true
 }


### PR DESCRIPTION
## Description
Setting tunnel PSK outputs to `sensitive = true` so that Terraform doesn't error out on apply when the custom PSK are used.

## Motivation and Context
Opened as an additional request in the [Issue#80](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/issues/80#issuecomment-1415442499), but not covered in the [PR#83](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/pull/83).

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [✓] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [✓] I have executed `pre-commit run -a` on my pull request

