### PR TITLE
feat: Output the pre-shared tunnel keys even when they are auto-generated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to use the Transit Gateway support you are responsible for creating 
 ```hcl
 module "vpn_gateway" {
   source  = "terraform-aws-modules/vpn-gateway/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   vpc_id                  = module.vpc.vpc_id
   vpn_gateway_id          = module.vpc.vgw_id
@@ -46,7 +46,7 @@ module "vpn_gateway" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   enable_vpn_gateway = true
   amazon_side_asn    = 64620
@@ -71,7 +71,7 @@ module "vpc" {
 ```hcl
 module "vpn_gateway" {
   source  = "terraform-aws-modules/vpn-gateway/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   vpn_gateway_id      = aws_vpn_gateway.vpn_gateway.id
   customer_gateway_id = aws_customer_gateway.main.id
@@ -113,7 +113,7 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 ```hcl
 module "vpn_gateway" {
   source  = "terraform-aws-modules/vpn-gateway/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   create_vpn_gateway_attachment = false
   connect_to_transit_gateway    = true
@@ -131,7 +131,7 @@ module "vpn_gateway" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   enable_vpn_gateway = false
   amazon_side_asn    = 64620
@@ -166,7 +166,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 ```hcl
 module "vpn_gateway" {
   source  = "terraform-aws-modules/vpn-gateway/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   create_vpn_gateway_attachment = false
   connect_to_transit_gateway    = true
@@ -184,7 +184,7 @@ module "vpn_gateway" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   enable_vpn_gateway = false
   amazon_side_asn    = 64620

--- a/examples/complete-dual-vpn-gateway/README.md
+++ b/examples/complete-dual-vpn-gateway/README.md
@@ -39,7 +39,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpn_gateway"></a> [vpn\_gateway](#module\_vpn\_gateway) | ../../ | n/a |
 | <a name="module_vpn_gateway2"></a> [vpn\_gateway2](#module\_vpn\_gateway2) | ../../ | n/a |
 
@@ -58,6 +58,8 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_vpn_connection_tunnel1_preshared_key"></a> [vpn\_connection\_tunnel1\_preshared\_key](#output\_vpn\_connection\_tunnel1\_preshared\_key) | Tunnel1 preshared key |
+| <a name="output_vpn_connection_tunnel2_preshared_key"></a> [vpn\_connection\_tunnel2\_preshared\_key](#output\_vpn\_connection\_tunnel2\_preshared\_key) | Tunnel2 preshared key |
 | <a name="output_vpn_gateway2_vpn_connection_id"></a> [vpn\_gateway2\_vpn\_connection\_id](#output\_vpn\_gateway2\_vpn\_connection\_id) | VPN id |
 | <a name="output_vpn_gateway2_vpn_connection_tunnel1_address"></a> [vpn\_gateway2\_vpn\_connection\_tunnel1\_address](#output\_vpn\_gateway2\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
 | <a name="output_vpn_gateway2_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_gateway2\_vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_gateway2\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |

--- a/examples/complete-dual-vpn-gateway/main.tf
+++ b/examples/complete-dual-vpn-gateway/main.tf
@@ -48,7 +48,7 @@ resource "aws_customer_gateway" "secondary" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = "complete-dual-vpn-gateway"
 

--- a/examples/complete-dual-vpn-gateway/outputs.tf
+++ b/examples/complete-dual-vpn-gateway/outputs.tf
@@ -33,6 +33,18 @@ output "vpn_gateway_vpn_connection_tunnel2_vgw_inside_address" {
   value       = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
 }
 
+output "vpn_connection_tunnel1_preshared_key" {
+  description = "Tunnel1 preshared key"
+  value       = module.vpn_gateway.tunnel1_preshared_key
+  sensitive   = true
+}
+
+output "vpn_connection_tunnel2_preshared_key" {
+  description = "Tunnel2 preshared key"
+  value       = module.vpn_gateway.tunnel2_preshared_key
+  sensitive   = true
+}
+
 ###VPN Connection Second VPN
 
 output "vpn_gateway2_vpn_connection_id" {

--- a/examples/complete-vpn-connection-transit-gateway/README.md
+++ b/examples/complete-vpn-connection-transit-gateway/README.md
@@ -32,7 +32,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpn_gateway_1"></a> [vpn\_gateway\_1](#module\_vpn\_gateway\_1) | ../../ | n/a |
 | <a name="module_vpn_gateway_2"></a> [vpn\_gateway\_2](#module\_vpn\_gateway\_2) | ../../ | n/a |
 
@@ -58,8 +58,10 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="output_vpn_connection_transit_gateway_attachment_id"></a> [vpn\_connection\_transit\_gateway\_attachment\_id](#output\_vpn\_connection\_transit\_gateway\_attachment\_id) | VPN TGW attachment id |
 | <a name="output_vpn_connection_tunnel1_address"></a> [vpn\_connection\_tunnel1\_address](#output\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
 | <a name="output_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |
+| <a name="output_vpn_connection_tunnel1_preshared_key"></a> [vpn\_connection\_tunnel1\_preshared\_key](#output\_vpn\_connection\_tunnel1\_preshared\_key) | Tunnel1 preshared key |
 | <a name="output_vpn_connection_tunnel1_vgw_inside_address"></a> [vpn\_connection\_tunnel1\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_vgw\_inside\_address) | Tunnel1 VGW address |
 | <a name="output_vpn_connection_tunnel2_address"></a> [vpn\_connection\_tunnel2\_address](#output\_vpn\_connection\_tunnel2\_address) | Tunnel2 address |
 | <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | Tunnel2 CGW address |
+| <a name="output_vpn_connection_tunnel2_preshared_key"></a> [vpn\_connection\_tunnel2\_preshared\_key](#output\_vpn\_connection\_tunnel2\_preshared\_key) | Tunnel2 preshared key |
 | <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | Tunnel2 VGW address |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-connection-transit-gateway/main.tf
+++ b/examples/complete-vpn-connection-transit-gateway/main.tf
@@ -42,7 +42,7 @@ module "vpn_gateway_2" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = "complete-vpn-gateway-transit-gateway"
 

--- a/examples/complete-vpn-connection-transit-gateway/outputs.tf
+++ b/examples/complete-vpn-connection-transit-gateway/outputs.tf
@@ -37,3 +37,15 @@ output "vpn_connection_transit_gateway_attachment_id" {
   description = "VPN TGW attachment id"
   value       = module.vpn_gateway_1.vpn_connection_transit_gateway_attachment_id
 }
+
+output "vpn_connection_tunnel1_preshared_key" {
+  description = "Tunnel1 preshared key"
+  value       = module.vpn_gateway_1.tunnel1_preshared_key
+  sensitive   = true
+}
+
+output "vpn_connection_tunnel2_preshared_key" {
+  description = "Tunnel2 preshared key"
+  value       = module.vpn_gateway_1.tunnel2_preshared_key
+  sensitive   = true
+}

--- a/examples/complete-vpn-gateway-with-static-routes/README.md
+++ b/examples/complete-vpn-gateway-with-static-routes/README.md
@@ -34,7 +34,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpn_gateway"></a> [vpn\_gateway](#module\_vpn\_gateway) | ../../ | n/a |
 
 ## Resources
@@ -57,8 +57,10 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="output_vpn_connection_id"></a> [vpn\_connection\_id](#output\_vpn\_connection\_id) | VPN id |
 | <a name="output_vpn_connection_tunnel1_address"></a> [vpn\_connection\_tunnel1\_address](#output\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
 | <a name="output_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |
+| <a name="output_vpn_connection_tunnel1_preshared_key"></a> [vpn\_connection\_tunnel1\_preshared\_key](#output\_vpn\_connection\_tunnel1\_preshared\_key) | Tunnel1 preshared key |
 | <a name="output_vpn_connection_tunnel1_vgw_inside_address"></a> [vpn\_connection\_tunnel1\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_vgw\_inside\_address) | Tunnel1 VGW address |
 | <a name="output_vpn_connection_tunnel2_address"></a> [vpn\_connection\_tunnel2\_address](#output\_vpn\_connection\_tunnel2\_address) | Tunnel2 address |
 | <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | Tunnel2 CGW address |
+| <a name="output_vpn_connection_tunnel2_preshared_key"></a> [vpn\_connection\_tunnel2\_preshared\_key](#output\_vpn\_connection\_tunnel2\_preshared\_key) | Tunnel2 preshared key |
 | <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | Tunnel2 VGW address |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-gateway-with-static-routes/main.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/main.tf
@@ -34,7 +34,7 @@ resource "aws_customer_gateway" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.0"
+  version = "~> 5.0"
 
   name = "complete-vpn-gateway-with-static-routes"
 

--- a/examples/complete-vpn-gateway-with-static-routes/outputs.tf
+++ b/examples/complete-vpn-gateway-with-static-routes/outputs.tf
@@ -32,3 +32,15 @@ output "vpn_connection_tunnel2_vgw_inside_address" {
   description = "Tunnel2 VGW address"
   value       = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
 }
+
+output "vpn_connection_tunnel1_preshared_key" {
+  description = "Tunnel1 preshared key"
+  value       = module.vpn_gateway.tunnel1_preshared_key
+  sensitive   = true
+}
+
+output "vpn_connection_tunnel2_preshared_key" {
+  description = "Tunnel2 preshared key"
+  value       = module.vpn_gateway.tunnel2_preshared_key
+  sensitive   = true
+}

--- a/examples/complete-vpn-gateway/README.md
+++ b/examples/complete-vpn-gateway/README.md
@@ -34,7 +34,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpn_gateway"></a> [vpn\_gateway](#module\_vpn\_gateway) | ../../ | n/a |
 
 ## Resources

--- a/examples/complete-vpn-gateway/README.md
+++ b/examples/complete-vpn-gateway/README.md
@@ -58,8 +58,10 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="output_vpn_connection_id"></a> [vpn\_connection\_id](#output\_vpn\_connection\_id) | VPN id |
 | <a name="output_vpn_connection_tunnel1_address"></a> [vpn\_connection\_tunnel1\_address](#output\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
 | <a name="output_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |
+| <a name="output_vpn_connection_tunnel1_preshared_key"></a> [vpn\_connection\_tunnel1\_preshared\_key](#output\_vpn\_connection\_tunnel1\_preshared\_key) | Tunnel1 preshared key |
 | <a name="output_vpn_connection_tunnel1_vgw_inside_address"></a> [vpn\_connection\_tunnel1\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_vgw\_inside\_address) | Tunnel1 VGW address |
 | <a name="output_vpn_connection_tunnel2_address"></a> [vpn\_connection\_tunnel2\_address](#output\_vpn\_connection\_tunnel2\_address) | Tunnel2 address |
 | <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | Tunnel2 CGW address |
+| <a name="output_vpn_connection_tunnel2_preshared_key"></a> [vpn\_connection\_tunnel2\_preshared\_key](#output\_vpn\_connection\_tunnel2\_preshared\_key) | Tunnel2 preshared key |
 | <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | Tunnel2 VGW address |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-vpn-gateway/main.tf
+++ b/examples/complete-vpn-gateway/main.tf
@@ -42,7 +42,7 @@ resource "aws_customer_gateway" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = "complete-vpn-gateway"
 

--- a/examples/complete-vpn-gateway/outputs.tf
+++ b/examples/complete-vpn-gateway/outputs.tf
@@ -32,3 +32,15 @@ output "vpn_connection_tunnel2_vgw_inside_address" {
   description = "Tunnel2 VGW address"
   value       = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
 }
+
+output "vpn_connection_tunnel1_preshared_key" {
+  description = "Tunnel1 preshared key"
+  value       = module.vpn_gateway.tunnel1_preshared_key
+  sensitive   = true
+}
+
+output "vpn_connection_tunnel2_preshared_key" {
+  description = "Tunnel2 preshared key"
+  value       = module.vpn_gateway.tunnel2_preshared_key
+  sensitive   = true
+}

--- a/examples/minimal-vpn-gateway/README.md
+++ b/examples/minimal-vpn-gateway/README.md
@@ -34,7 +34,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpn_gateway"></a> [vpn\_gateway](#module\_vpn\_gateway) | ../../ | n/a |
 
 ## Resources
@@ -56,8 +56,10 @@ Run `terraform destroy` when you don't need these resources.
 | <a name="output_vpn_connection_id"></a> [vpn\_connection\_id](#output\_vpn\_connection\_id) | VPN id |
 | <a name="output_vpn_connection_tunnel1_address"></a> [vpn\_connection\_tunnel1\_address](#output\_vpn\_connection\_tunnel1\_address) | Tunnel1 address |
 | <a name="output_vpn_connection_tunnel1_cgw_inside_address"></a> [vpn\_connection\_tunnel1\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_cgw\_inside\_address) | Tunnel1 CGW address |
+| <a name="output_vpn_connection_tunnel1_preshared_key"></a> [vpn\_connection\_tunnel1\_preshared\_key](#output\_vpn\_connection\_tunnel1\_preshared\_key) | Tunnel1 preshared key |
 | <a name="output_vpn_connection_tunnel1_vgw_inside_address"></a> [vpn\_connection\_tunnel1\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel1\_vgw\_inside\_address) | Tunnel1 VGW address |
 | <a name="output_vpn_connection_tunnel2_address"></a> [vpn\_connection\_tunnel2\_address](#output\_vpn\_connection\_tunnel2\_address) | Tunnel2 address |
 | <a name="output_vpn_connection_tunnel2_cgw_inside_address"></a> [vpn\_connection\_tunnel2\_cgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_cgw\_inside\_address) | Tunnel2 CGW address |
+| <a name="output_vpn_connection_tunnel2_preshared_key"></a> [vpn\_connection\_tunnel2\_preshared\_key](#output\_vpn\_connection\_tunnel2\_preshared\_key) | Tunnel2 preshared key |
 | <a name="output_vpn_connection_tunnel2_vgw_inside_address"></a> [vpn\_connection\_tunnel2\_vgw\_inside\_address](#output\_vpn\_connection\_tunnel2\_vgw\_inside\_address) | Tunnel2 VGW address |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/minimal-vpn-gateway/main.tf
+++ b/examples/minimal-vpn-gateway/main.tf
@@ -27,7 +27,7 @@ resource "aws_customer_gateway" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = "minimal-vpn-gateway"
 

--- a/examples/minimal-vpn-gateway/outputs.tf
+++ b/examples/minimal-vpn-gateway/outputs.tf
@@ -32,3 +32,15 @@ output "vpn_connection_tunnel2_vgw_inside_address" {
   description = "Tunnel2 VGW address"
   value       = module.vpn_gateway.vpn_connection_tunnel2_vgw_inside_address
 }
+
+output "vpn_connection_tunnel1_preshared_key" {
+  description = "Tunnel1 preshared key"
+  value       = module.vpn_gateway.tunnel1_preshared_key
+  sensitive   = true
+}
+
+output "vpn_connection_tunnel2_preshared_key" {
+  description = "Tunnel2 preshared key"
+  value       = module.vpn_gateway.tunnel2_preshared_key
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,22 +91,22 @@ output "vpn_connection_customer_gateway_configuration" {
 
 output "tunnel1_preshared_key" {
   description = "The preshared key of the first VPN tunnel."
-  value = one(compact([
-    try(aws_vpn_connection.default[0].tunnel1_preshared_key, null),
-    try(aws_vpn_connection.preshared[0].tunnel1_preshared_key, null),
-    try(aws_vpn_connection.tunnel[0].tunnel1_preshared_key, null),
-    try(aws_vpn_connection.tunnel_preshared[0].tunnel1_preshared_key, null),
-  ]))
+  value = try(
+    aws_vpn_connection.default[0].tunnel1_preshared_key,
+    aws_vpn_connection.preshared[0].tunnel1_preshared_key,
+    aws_vpn_connection.tunnel[0].tunnel1_preshared_key,
+    aws_vpn_connection.tunnel_preshared[0].tunnel1_preshared_key,
+  "")
   sensitive = true
 }
 
 output "tunnel2_preshared_key" {
   description = "The preshared key of the second VPN tunnel."
-  value = one(compact([
-    try(aws_vpn_connection.default[0].tunnel2_preshared_key, null),
-    try(aws_vpn_connection.preshared[0].tunnel2_preshared_key, null),
-    try(aws_vpn_connection.tunnel[0].tunnel2_preshared_key, null),
-    try(aws_vpn_connection.tunnel_preshared[0].tunnel2_preshared_key, null)
-  ]))
+  value = try(
+    aws_vpn_connection.default[0].tunnel2_preshared_key,
+    aws_vpn_connection.preshared[0].tunnel2_preshared_key,
+    aws_vpn_connection.tunnel[0].tunnel2_preshared_key,
+    aws_vpn_connection.tunnel_preshared[0].tunnel2_preshared_key,
+  "")
   sensitive = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,12 +91,22 @@ output "vpn_connection_customer_gateway_configuration" {
 
 output "tunnel1_preshared_key" {
   description = "The preshared key of the first VPN tunnel."
-  value       = var.tunnel1_preshared_key
-  sensitive   = true
+  value = one(compact([
+    try(aws_vpn_connection.default[0].tunnel1_preshared_key, null),
+    try(aws_vpn_connection.preshared[0].tunnel1_preshared_key, null),
+    try(aws_vpn_connection.tunnel[0].tunnel1_preshared_key, null),
+    try(aws_vpn_connection.tunnel_preshared[0].tunnel1_preshared_key, null),
+  ]))
+  sensitive = true
 }
 
 output "tunnel2_preshared_key" {
   description = "The preshared key of the second VPN tunnel."
-  value       = var.tunnel2_preshared_key
-  sensitive   = true
+  value = one(compact([
+    try(aws_vpn_connection.default[0].tunnel2_preshared_key, null),
+    try(aws_vpn_connection.preshared[0].tunnel2_preshared_key, null),
+    try(aws_vpn_connection.tunnel[0].tunnel2_preshared_key, null),
+    try(aws_vpn_connection.tunnel_preshared[0].tunnel2_preshared_key, null)
+  ]))
+  sensitive = true
 }


### PR DESCRIPTION
The AWS cli nor this module require the user to provide tunnel keys for the tunnel to be created. In the event that no keys were provided AWS will automatically generate the tunnel keys. However the user will have no way to retrieve these currently in this module or via the AWS terraform provider as it doesn't expose a `data` resource to the tunnel options.

Currently this module will blindly return only the pre-shared keys that were provided. This PR seeks to return the pre-shared keys to the user from the `aws_vpn_connection` instead. This will ensure the caller gets access to the pre-shared keys even if they are auto-generated


## Description
In the `output.tf` updated the value of the preshared key output for tunnel1 and tunnel2 to instead of returning just the var input. It will look for the pre-shared key output from each of the 4 scenarions, compact them to remove the null values and ensure only one value exists and is returned for each tunnel.

## Motivation and Context
As part of terraform deployment we create the vpn connection for the project team allowing AWS to create the PSK. We planned to store the PSK in hashicorp vault at a location the projec team has access to so they could then share this with the client/customer to configure the customer gateway at their side. However we had no access to the auto-generated PSK via terraform AWS provider.

This PR would allow us to get the auto-generated PSK from the module and then use the vault provider to store that as a secret in hashicorp vault for later access.

## Breaking Changes
There should be no breaking changes here. The output specification has not changed, just the internal implementation that looks for the PSK to return. Even in the use cases where the PSK was provided as VAR by the user will still work as that will be the same PSK thats in the `aws_vpn_connection` resource.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I have run the `complete-vpn-gateway` example and validated the output matches that of the tunnel configuration in AWS