### PR TITLE
feat: Set input PSK to `sensitive = true`. Validate length of PSKs

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,22 @@ variable "tunnel1_preshared_key" {
   description = "The preshared key of the first VPN tunnel."
   type        = string
   default     = ""
+  sensitive   = true
+  validation {
+    condition     = length(var.tunnel1_preshared_key) == 0 || (length(var.tunnel1_preshared_key) >= 8 && length(var.tunnel1_preshared_key) <= 64)
+    error_message = "Must be between 8 and 64 characters"
+  }
 }
 
 variable "tunnel2_preshared_key" {
   description = "The preshared key of the second VPN tunnel."
   type        = string
   default     = ""
+  sensitive   = true
+  validation {
+    condition     = length(var.tunnel2_preshared_key) == 0 || (length(var.tunnel2_preshared_key) >= 8 && length(var.tunnel2_preshared_key) <= 64)
+    error_message = "Must be between 8 and 64 characters"
+  }
 }
 
 # Attachment can be already managed by the terraform-aws-vpc module by using the enable_vpn_gateway variable


### PR DESCRIPTION
## Description
Setting the tunnel PSK inputs to `sensitive = true` so that if Terraform errors out on a plan (for example, a PSK longer than 64 characters), the error message does not contain the PSK. Also, validate the length of the PSKs

## Motivation and Context
This complements [PR#86](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway/pull/86), but it didn't cover the case for an erroneous plan.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
