### PR TITLE
fix: Add `dpd_timeout_seconds` to `tunnel_preshared`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -371,6 +371,9 @@ resource "aws_vpn_connection" "tunnel_preshared" {
   tunnel1_phase1_lifetime_seconds = var.tunnel1_phase1_lifetime_seconds
   tunnel2_phase1_lifetime_seconds = var.tunnel2_phase1_lifetime_seconds
 
+  tunnel1_dpd_timeout_seconds = var.tunnel1_dpd_timeout_seconds
+  tunnel2_dpd_timeout_seconds = var.tunnel2_dpd_timeout_seconds
+
   tunnel1_dpd_timeout_action = var.tunnel1_dpd_timeout_action
   tunnel2_dpd_timeout_action = var.tunnel2_dpd_timeout_action
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

I think this is a simple typo, you guys are missing dpd_timeout_seconds  in resource "vpn_connection" **tunnel_preshared**  for both tunnels 1 & 2

Nothing to really test, these variables are missing and its clear they are in other types of vpn_connectino resources in your file except for tunnel_preshared. 

As proof - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_connection

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
